### PR TITLE
fix: crash when Compose Resources throws MissingResourceException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed DevView overlay back navigation: the overlay's back handler now correctly yields priority to the host app when closed, preventing it from silently consuming back events.
+- Fixed crash on Network Mock screen startup: `MissingResourceException` thrown by Compose Resources when probing absent response files was not caught by the `IllegalStateException` handler in `MockConfigRepository`, causing a fatal crash. The exception is now normalised at the `NetworkMock` boundary before reaching the core module.
 
 ## [0.1.2] - 2026-07-17
 

--- a/devview-networkmock/src/commonMain/kotlin/com/worldline/devview/networkmock/NetworkMock.kt
+++ b/devview-networkmock/src/commonMain/kotlin/com/worldline/devview/networkmock/NetworkMock.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.PolymorphicModuleBuilder
+import org.jetbrains.compose.resources.MissingResourceException
 
 /**
  * Navigation destinations for the NetworkMock module.
@@ -111,7 +112,13 @@ public class NetworkMock(
         NetworkMockInitializer.initialize(
             dataStore = dataStoreDelegate.get(),
             configPath = configPath,
-            resourceLoader = resourceLoader
+            resourceLoader = { path ->
+                try {
+                    resourceLoader(path)
+                } catch (e: MissingResourceException) {
+                    throw IllegalStateException(e.message, e)
+                }
+            }
         )
     }
 


### PR DESCRIPTION
MissingResourceException (extends Exception) was not caught by the IllegalStateException handler in MockConfigRepository.loadMockResponseFromPath, causing a fatal crash when probing response file paths that don't exist. Normalise the exception type at the NetworkMock boundary before it reaches the core module, which has no dependency on Compose Resources by design.