### PR TITLE
docs: Audit and overhaul CLAUDE.md and docs site

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,5 +15,8 @@
       "Bash(ls *)",
       "Bash(cat *)"
     ]
+  },
+  "enabledPlugins": {
+    "claude-md-management@claude-plugins-official": true
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,17 @@ On Windows, use `.\gradlew.bat` instead of `./gradlew`. Always append `-Pandroid
 ./gradlew :devview:koverXmlReport :devview:koverLog
 ```
 
+**Docs (local preview):**
+```shell
+pip install zensical==0.0.50
+zensical serve
+```
+
+**Docs (full build including Dokka API docs):**
+```shell
+./scripts/build_docs.sh build
+```
+
 ## Architecture
 
 ### Module Graph
@@ -64,6 +75,7 @@ devview-networkmock-ktor  (Ktor client plugin intercepting requests via networkm
 devview-test           (shared test utilities: FakePreferencesDataStore, Turbine wrappers)
 konsist/               (Konsist architecture enforcement tests)
 sample/                (sample Android app showing full integration)
+internal/dokka         (Dokka aggregation for published API docs)
 ```
 
 ### Key Concepts

--- a/docs/contributing/code-of-conduct.md
+++ b/docs/contributing/code-of-conduct.md
@@ -2,8 +2,6 @@
 
 We are committed to providing a welcoming and inclusive environment for all contributors. Please follow these guidelines to ensure a positive experience for everyone.
 
-> _[Placeholder: Insert screenshot or diagram illustrating community standards. Use a device frame if relevant.]_
-
 ## Our Standards
 - Be respectful and constructive in all interactions
 - Use inclusive language

--- a/docs/contributing/code-style.md
+++ b/docs/contributing/code-style.md
@@ -2,8 +2,6 @@
 
 Code style guidelines for DevView.
 
-> _[Placeholder: Insert screenshot or diagram of code style checks in action. Use a device frame if relevant.]_
-
 ## Formatting
 - Use Kotlin's official style guide
 - Indent with 4 spaces

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -2,8 +2,6 @@
 
 We welcome contributions from the community! This guide explains how to get started, development setup, code style, submitting pull requests, and our code of conduct.
 
-> _[Placeholder: Insert diagram or screenshot showing the contribution workflow. Use a device frame if relevant.]_
-
 ## Ways to Contribute
 - 🐛 Report bugs
 - 💡 Suggest features

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -2,8 +2,6 @@
 
 How to submit pull requests to DevView.
 
-> _[Placeholder: Insert screenshot or diagram of the pull request workflow. Use a device frame if relevant.]_
-
 ## Before You Submit
 - Ensure your branch is up to date with main
 - Run all tests and code quality checks

--- a/docs/examples/advanced-examples.md
+++ b/docs/examples/advanced-examples.md
@@ -2,22 +2,26 @@
 
 Explore advanced usage scenarios for DevView, including custom modules, multi-module integration, and workflows. These examples demonstrate how to extend DevView for complex developer needs.
 
-> _[Placeholder: Insert diagram or screenshot illustrating advanced DevView usage. Use a device frame if relevant.]_
-
 ## Custom Module Example
 ```kotlin
 object MyAdvancedModule : Module {
     override val moduleName = "Advanced Tool"
     override val section = Section.CUSTOM
-    override val destinations = persistentListOf(MyDestination.Main)
-    override val registerSerialisers = { /* ... */ }
-    override fun EntryProviderScope<NavKey>.registerContent(...) { /* ... */ }
+    override val destinations: PersistentMap<KClass<out NavKey>, DestinationMetadata> =
+        persistentMapOf(MyDestination.Main.withTitle("Advanced Tool"))
+    override val entryDestination: NavKey = MyDestination.Main
+    override val registerSerializers: PolymorphicModuleBuilder<NavKey>.() -> Unit = { /* ... */ }
+    override fun EntryProviderScope<NavKey>.registerContent(
+        onNavigateBack: () -> Unit,
+        onNavigate: (NavKey) -> Unit,
+        bottomPadding: Dp,
+    ) { /* ... */ }
 }
 val modules = rememberModules {
     module(MyAdvancedModule)
     module(FeatureFlip)
-    module(Analytics)
-    module(NetworkMock)
+    module(Analytics())
+    module(NetworkMock(resourceLoader = { path -> Res.readBytes(path) }))
 }
 ```
 

--- a/docs/examples/analytics-tracking.md
+++ b/docs/examples/analytics-tracking.md
@@ -2,26 +2,24 @@
 
 Monitoring analytics events with the Analytics module.
 
-> _[Placeholder: Insert screenshot of Analytics UI showing tracked events. Use a device frame if relevant.]_
-
 ## Step 1: Log Analytics Events
 ```kotlin
 // Screen view
 AnalyticsLogger.log(
     AnalyticsLog(
-        tag = "HomeScreen",
+        tag = "home_screen_view",
         screenClass = "com.app.HomeScreen",
         timestamp = System.currentTimeMillis(),
-        type = AnalyticsLogType.SCREEN
+        type = AnalyticsLogCategory.Screen.View
     )
 )
-// User event
+// User action
 AnalyticsLogger.log(
     AnalyticsLog(
         tag = "button_click",
         screenClass = "HomeScreen",
         timestamp = System.currentTimeMillis(),
-        type = AnalyticsLogType.EVENT
+        type = AnalyticsLogCategory.Action.Click
     )
 )
 ```
@@ -29,7 +27,7 @@ AnalyticsLogger.log(
 ## Step 2: Register Analytics Module
 ```kotlin
 val modules = rememberModules {
-    module(Analytics)
+    module(Analytics()) // constructor params customize summary chip types
     // ...other modules...
 }
 ```
@@ -38,8 +36,15 @@ val modules = rememberModules {
 ```kotlin
 @Composable
 fun MyApp() {
+    // AnalyticsScreen is rendered automatically when Analytics() is registered in rememberModules.
+    // To use it standalone:
     CompositionLocalProvider(LocalAnalytics provides AnalyticsLogger.logs) {
-        AnalyticsScreen()
+        AnalyticsScreen(
+            highlightedAnalyticsLogTypes = persistentListOf(
+                AnalyticsLogCategory.Action.Click,
+                AnalyticsLogCategory.Performance.Error
+            )
+        )
     }
 }
 ```

--- a/docs/examples/android.md
+++ b/docs/examples/android.md
@@ -2,8 +2,6 @@
 
 Complete Android integration example.
 
-> _[Placeholder: Insert screenshot of DevView running in an Android app. Use a device frame if relevant.]_
-
 ## Prerequisites
 - Android Studio Giraffe or newer
 - Minimum API level 21

--- a/docs/examples/feature-flags.md
+++ b/docs/examples/feature-flags.md
@@ -2,8 +2,6 @@
 
 Managing feature toggles with FeatureFlip.
 
-> _[Placeholder: Insert screenshot of FeatureFlip UI showing feature toggles. Use a device frame if relevant.]_
-
 ## Step 1: Define Features
 ```kotlin
 val darkMode = Feature.LocalFeature(
@@ -28,12 +26,12 @@ val modules = rememberModules {
 }
 ```
 
-## Step 3: Use FeatureFlipScreen in Your Composable
+## Step 3: Provide the FeatureHandler to your composable tree
 ```kotlin
-CompositionLocalProvider(LocalFeatures provides features) {
-    FeatureFlipScreen(onStateChange = { featureName, newState ->
-        // Handle state change
-    })
+val featureHandler = rememberFeatureHandler(features)
+CompositionLocalProvider(LocalFeatureHandler provides featureHandler) {
+    // FeatureFlipScreen is rendered automatically by DevView when FeatureFlip is registered.
+    // State changes are persisted to DataStore internally.
 }
 ```
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -2,8 +2,6 @@
 
 Explore practical examples for integrating and using DevView in your projects. These examples cover Android, iOS, feature flags, analytics tracking, and advanced scenarios.
 
-> _[Placeholder: Insert screenshot or diagram showing example DevView screens on Android and iOS. Use a device frame if relevant.]_
-
 ## Available Examples
 - [Android Setup](android.md): Step-by-step integration in an Android app
 - [iOS Setup](ios.md): Step-by-step integration in an iOS app
@@ -15,7 +13,6 @@ Explore practical examples for integrating and using DevView in your projects. T
 - Follow the step-by-step instructions in each example
 - Copy and adapt code snippets to your own project
 - Refer to troubleshooting tips for common issues
-- Use placeholders to add your own screenshots or diagrams
 
 ## Sample Code
 Check the `sample/` directory in the repository for complete working examples.

--- a/docs/examples/ios.md
+++ b/docs/examples/ios.md
@@ -2,8 +2,6 @@
 
 Complete iOS integration example.
 
-> _[Placeholder: Insert screenshot of DevView running in an iOS app. Use a device frame if relevant.]_
-
 ## Prerequisites
 - Xcode 15 or newer
 - Minimum iOS 16.0

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -2,8 +2,6 @@
 
 Advanced configuration options for DevView.
 
-> _[Placeholder: Insert screenshot of DevView configuration UI or module selection. Use a device frame if relevant.]_
-
 ## Module Configuration
 
 ### Conditional Modules
@@ -73,7 +71,7 @@ object MyModule : Module {
 
 ## Custom Modules
 
-> _[Placeholder: Guide for developing custom DevView modules. This section will be expanded in future updates.]_
+See the [Creating Custom Modules](../modules/custom-modules.md) guide for a full example.
 
 ## Troubleshooting
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -45,7 +45,7 @@ Add DevView dependencies to your `gradle/libs.versions.toml`:
 
 ```toml
 [versions]
-devview = "0.1.1"
+devview = "DEVVIEW_VERSION"
 
 [libraries]
 devview = { module = "com.worldline.devview:devview", version.ref = "devview" }
@@ -85,13 +85,13 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             // Core DevView module (required)
-            implementation("com.worldline.devview:devview:0.1.1")
+            implementation("com.worldline.devview:devview:<version>")
             
             // Optional: FeatureFlip module
-            implementation("com.worldline.devview:devview-featureflip:0.1.1")
+            implementation("com.worldline.devview:devview-featureflip:<version>")
             
             // Optional: Analytics module
-            implementation("com.worldline.devview:devview-analytics:0.1.1")
+            implementation("com.worldline.devview:devview-analytics:<version>")
         }
     }
 }

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -2,8 +2,6 @@
 
 Get DevView up and running in your application in just a few minutes!
 
-> _[Placeholder: Insert screenshot of DevView UI in an app. Use a device frame if relevant.]_
-
 ## Step 1: Create Your App Structure
 Set up your main app structure and state for DevView.
 
@@ -25,8 +23,8 @@ Configure which DevView modules you want to use.
 ```kotlin
 val modules = rememberModules {
     module(FeatureFlip)
-    module(Analytics)
-    module(NetworkMock) // Optional: Add network mocking
+    module(Analytics())
+    module(NetworkMock(resourceLoader = { path -> Res.readBytes(path) })) // Optional
 }
 ```
 
@@ -55,8 +53,8 @@ fun App() {
     var isDevViewOpen by remember { mutableStateOf(false) }
     val modules = rememberModules {
         module(FeatureFlip)
-        module(Analytics)
-        module(NetworkMock)
+        module(Analytics())
+        module(NetworkMock(resourceLoader = { path -> Res.readBytes(path) }))
     }
     Box(modifier = Modifier.fillMaxSize()) {
         MainAppContent()
@@ -76,7 +74,7 @@ fun App() {
 
 ## Custom Modules
 
-> _[Placeholder: Describe how to add custom DevView modules. This section will be expanded in future updates.]_
+See the [Creating Custom Modules](../modules/custom-modules.md) guide for a full example.
 
 ## Troubleshooting
 For common integration issues, see the [troubleshooting section](troubleshooting-faq.md).

--- a/docs/getting-started/troubleshooting-faq.md
+++ b/docs/getting-started/troubleshooting-faq.md
@@ -2,8 +2,6 @@
 
 Find solutions to common issues and answers to frequently asked questions when integrating or using DevView.
 
-> _[Placeholder: Insert screenshot or diagram of a typical error message or troubleshooting UI. Use a device frame if relevant.]_
-
 ## General Troubleshooting
 
 ### DevView not appearing
@@ -44,7 +42,7 @@ Find solutions to common issues and answers to frequently asked questions when i
 DevView is intended for development and debugging purposes. It is not recommended to include DevView in production builds.
 
 ### How do I add a custom module?
-> _[Placeholder: Add step-by-step guide for custom module integration. This section will be expanded in future updates.]_
+See the [Creating Custom Modules](../modules/custom-modules.md) guide for a full example.
 
 ### Is DevView compatible with all Compose Multiplatform targets?
 DevView supports Android and iOS targets. Other platforms may require additional configuration or are not officially supported yet.

--- a/docs/guides/best-practices.md
+++ b/docs/guides/best-practices.md
@@ -2,8 +2,6 @@
 
 Recommended patterns and practices for using DevView.
 
-> _[Placeholder: Insert diagram or screenshot illustrating best practices in DevView usage. Use a device frame if relevant.]_
-
 ## General Principles
 - Keep modules focused and single-purpose
 - Use type-safe navigation and state management

--- a/docs/guides/common-pitfalls.md
+++ b/docs/guides/common-pitfalls.md
@@ -2,8 +2,6 @@
 
 Avoid these common mistakes when integrating and extending DevView. This guide provides troubleshooting tips and best practices to help you build robust developer tools.
 
-> _[Placeholder: Insert diagram or screenshot illustrating common mistakes and solutions. Use a device frame if relevant.]_
-
 ## Module Registration
 - Forgetting to register modules in `rememberModules`.
 - Registering duplicate modules or conflicting names.

--- a/docs/guides/integration-guide.md
+++ b/docs/guides/integration-guide.md
@@ -2,8 +2,6 @@
 
 This guide walks you through integrating DevView into a new or existing Kotlin Multiplatform project, with platform-specific notes and troubleshooting tips.
 
-> _[Placeholder: Insert screenshot or diagram of DevView integration in a project. Use a device frame if relevant.]_
-
 ## Step 1: Prepare Your Project
 - Ensure your project is set up for Kotlin Multiplatform and Compose Multiplatform.
 - Confirm minimum supported versions (see Prerequisites).

--- a/docs/guides/module-development.md
+++ b/docs/guides/module-development.md
@@ -2,8 +2,6 @@
 
 In-depth guide for creating DevView modules.
 
-> _[Placeholder: Insert diagram or screenshot of a module development workflow. Use a device frame if relevant.]_
-
 ## Module Structure
 A DevView module consists of:
 1. **Destinations** - Navigation screens
@@ -29,16 +27,19 @@ object MyModule : Module {
     override val moduleName = "My Module"
     override val section = Section.CUSTOM
     override val subtitle = "Custom developer tool"
-    override val destinations = persistentListOf(
-        MyModuleDestination.Main
+    override val destinations: PersistentMap<KClass<out NavKey>, DestinationMetadata> = persistentMapOf(
+        MyModuleDestination.Main.withTitle("My Module"),
+        MyModuleDestination.Detail::class.asDestination()
     )
-    override val registerSerialisers: PolymorphicModuleBuilder<NavKey>.() -> Unit = {
+    override val entryDestination: NavKey = MyModuleDestination.Main
+    override val registerSerializers: PolymorphicModuleBuilder<NavKey>.() -> Unit = {
         subclass(MyModuleDestination.Main::class, MyModuleDestination.Main.serializer())
         subclass(MyModuleDestination.Detail::class, MyModuleDestination.Detail.serializer())
     }
     override fun EntryProviderScope<NavKey>.registerContent(
         onNavigateBack: () -> Unit,
-        onNavigate: (NavKey) -> Unit
+        onNavigate: (NavKey) -> Unit,
+        bottomPadding: Dp,
     ) {
         entry<MyModuleDestination.Main> {
             MyModuleMainScreen(
@@ -84,9 +85,6 @@ val modules = rememberModules {
 }
 ```
 
-## Customisation
-> _[Placeholder: Guide for customising modules. This section will be expanded in future updates.]_
-
 ## Architecture Best Practices
 - Keep modules focused and single-purpose
 - Use proper state management
@@ -95,9 +93,6 @@ val modules = rememberModules {
 - Test on both platforms
 - Use descriptive names and icons for your module
 - Group related screens under a single module
-
-## Advanced Scenarios
-> _[Placeholder: Multi-screen modules, platform-specific customisation, complex navigation, and advanced UI patterns.]_
 
 ## Troubleshooting
 - **Module not appearing?** Ensure it is registered and implements the required interface.
@@ -110,4 +105,5 @@ val modules = rememberModules {
 - Explore [Navigation](navigation.md) for advanced navigation patterns.
 
 ## API Reference
-> _[API reference available via Dokka. Add direct link here when available.]_
+
+See the [Dokka API Reference](../api/index.html) for full API documentation.

--- a/docs/guides/navigation.md
+++ b/docs/guides/navigation.md
@@ -2,8 +2,6 @@
 
 Understanding DevView's type-safe navigation system.
 
-> _[Placeholder: Insert diagram of navigation flow in a DevView module. Use a device frame if relevant.]_
-
 ## Navigation Architecture
 DevView uses Navigation3 with kotlinx.serialization for type-safe navigation. Destinations are defined as sealed interfaces implementing NavKey, and navigation is handled via callbacks.
 
@@ -21,7 +19,7 @@ sealed interface MyDestination : NavKey {
 
 ### 2. Register Destinations and Serialisers
 ```kotlin
-override val registerSerialisers = {
+override val registerSerializers: PolymorphicModuleBuilder<NavKey>.() -> Unit = {
     subclass(MyDestination.Main::class, MyDestination.Main.serializer())
     subclass(MyDestination.Detail::class, MyDestination.Detail.serializer())
 }
@@ -50,9 +48,6 @@ entry<MyDestination.Detail> { destination ->
 - Keep navigation flows simple and predictable
 - Document all navigation paths
 - Test navigation on all supported platforms
-
-## Advanced Patterns
-> _[Placeholder: Deep linking, multi-module navigation, platform-specific navigation customisation.]_
 
 ## Troubleshooting
 - **Navigation not working?** Check destination and serialiser definitions.

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -2,8 +2,6 @@
 
 Customising the appearance of DevView.
 
-> _[Placeholder: Insert screenshot of DevView UI in light and dark themes. Use a device frame if relevant.]_
-
 ## Overview
 DevView is designed to inherit your app's theme, using MaterialTheme and Compose best practices. This ensures a consistent look and feel across all modules and platforms.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,7 +85,7 @@ fun App() {
     var isDevViewOpen by remember { mutableStateOf(false) }
     val modules = rememberModules {
         module(FeatureFlip)
-        module(Analytics)
+        module(Analytics())
     }
     Box {
         // Your main app content
@@ -207,6 +207,7 @@ graph TD
     A[DevView Framework] --> B[Core Module]
     A --> C[FeatureFlip Module]
     A --> D[Analytics Module]
+    A --> NM[NetworkMock Module]
     A --> E[Custom Modules]
     B --> F[Module Registry]
     B --> G[Navigation System]
@@ -215,6 +216,9 @@ graph TD
     C --> J[DataStore Persistence]
     D --> K[Analytics Logger]
     D --> L[Event Display]
+    NM --> MC[Mock Config Engine]
+    NM --> MS[Mock State DataStore]
+    NM --> KP[Ktor Plugin]
 ```
 
 ---

--- a/docs/modules/analytics.md
+++ b/docs/modules/analytics.md
@@ -2,8 +2,6 @@
 
 A Kotlin Multiplatform library for capturing and visualising analytics events in real time, providing a developer-friendly interface for monitoring and debugging analytics integration in your application.
 
-> _[Placeholder: Insert screenshot of Analytics UI. Use a device frame if relevant.]_
-
 ## Overview
 Analytics enables real-time monitoring of analytics events (screen views, custom events, etc.) with a built-in Compose UI for debugging and QA.
 
@@ -27,7 +25,7 @@ dependencies {
 Add Analytics to your DevView modules list:
 ```kotlin
 val modules = rememberModules {
-    module(Analytics)
+    module(Analytics()) // optional: pass highlightedLogType1/2/3 to customize summary chips
     // ...other modules...
 }
 ```
@@ -37,18 +35,25 @@ val modules = rememberModules {
 ```kotlin
 AnalyticsLogger.log(
     AnalyticsLog(
-        tag = "HomeScreen",
+        tag = "home_screen_view",
         screenClass = "com.example.ui.HomeScreen",
         timestamp = System.currentTimeMillis(),
-        type = AnalyticsLogType.SCREEN
+        type = AnalyticsLogCategory.Screen.View
     )
 )
 ```
 
 ### Using the UI
 ```kotlin
+// AnalyticsScreen is rendered automatically by DevView when Analytics() is registered.
+// To use it standalone, provide LocalAnalytics above it:
 CompositionLocalProvider(LocalAnalytics provides AnalyticsLogger.logs) {
-    AnalyticsScreen(modifier = Modifier.fillMaxSize())
+    AnalyticsScreen(
+        highlightedAnalyticsLogTypes = persistentListOf(
+            AnalyticsLogCategory.Action.Click,
+            AnalyticsLogCategory.Performance.Error
+        )
+    )
 }
 ```
 
@@ -56,12 +61,6 @@ CompositionLocalProvider(LocalAnalytics provides AnalyticsLogger.logs) {
 - Use `AnalyticsLogger.log()` to record events.
 - Use `AnalyticsScreen` to view logs in real time.
 - Integrate with your analytics backend for dual logging.
-
-## Customisation
-> _[Placeholder: Guide for customising Analytics UI and behaviour. This section will be expanded in future updates.]_
-
-## Advanced Usage
-> _[Placeholder: Advanced scenarios such as integration with external analytics backends, filtering, and platform-specific customisation.]_
 
 ## Best Practices
 1. Use descriptive tags and include screen context.

--- a/docs/modules/custom-modules.md
+++ b/docs/modules/custom-modules.md
@@ -12,17 +12,18 @@ DevView is built around a modular architecture. The **core module** provides the
 ### Module Interface
 ```kotlin
 interface Module {
-    val moduleName: String
+    val moduleName: String  // defaults to class simple name
     val section: Section
-    val icon: ImageVector
-    val containerColor: Color
-    val contentColor: Color
-    val subtitle: String?
-    val destinations: ImmutableList<NavKey>
+    val icon: ImageVector   // defaults to section icon
+    val subtitle: String?   // optional description text, defaults to null
+    val destinations: PersistentMap<KClass<out NavKey>, DestinationMetadata>
+    val entryDestination: NavKey
     val registerSerializers: PolymorphicModuleBuilder<NavKey>.() -> Unit
+    fun initModule() {}     // optional, called once after DataStore init
     fun EntryProviderScope<NavKey>.registerContent(
         onNavigateBack: () -> Unit,
-        onNavigate: (NavKey) -> Unit
+        onNavigate: (NavKey) -> Unit,
+        bottomPadding: Dp,
     )
 }
 ```
@@ -32,6 +33,7 @@ interface Module {
 enum class Section {
     SETTINGS,   // Configuration and app info
     FEATURES,   // Feature flags and dev tools
+    NETWORK,    // Network-related modules
     LOGGING,    // Analytics, logs, monitoring
     CUSTOM      // App-specific modules
 }
@@ -72,13 +74,19 @@ object MyTool : Module {
     override val moduleName = "My Tool"
     override val section = Section.CUSTOM
     override val subtitle = "Custom developer tool"
-    override val destinations = persistentListOf(
-        MyToolDestination.Main
+
+    override val destinations: PersistentMap<KClass<out NavKey>, DestinationMetadata> = persistentMapOf(
+        MyToolDestination.Main.withTitle("My Tool"),
+        MyToolDestination.Detail::class.asDestination()
     )
+
+    override val entryDestination: NavKey = MyToolDestination.Main
+
     override val registerSerializers: PolymorphicModuleBuilder<NavKey>.() -> Unit = {
         subclass(MyToolDestination.Main::class, MyToolDestination.Main.serializer())
         subclass(MyToolDestination.Detail::class, MyToolDestination.Detail.serializer())
     }
+
     override fun EntryProviderScope<NavKey>.registerContent(
         onNavigateBack: () -> Unit,
         onNavigate: (NavKey) -> Unit,
@@ -87,9 +95,7 @@ object MyTool : Module {
         entry<MyToolDestination.Main> {
             MyToolMainScreen(
                 onNavigateBack = onNavigateBack,
-                onDetailClick = { id ->
-                    onNavigate(MyToolDestination.Detail(id))
-                }
+                onDetailClick = { id -> onNavigate(MyToolDestination.Detail(id)) }
             )
         }
         entry<MyToolDestination.Detail> { destination ->
@@ -128,16 +134,8 @@ val modules = rememberModules {
 }
 ```
 
-> _[Placeholder: Insert screenshot or diagram of a custom module UI. Use a device frame if relevant.]_
-
 ## Examples
 See [Examples section](../examples/index.md) for complete custom module examples.
-
-## Customisation
-> _[Placeholder: Guide for customising the appearance and behaviour of custom modules. This section will be expanded in future updates.]_
-
-## Advanced Usage
-> _[Placeholder: Advanced scenarios such as multi-screen modules, platform-specific customisation, and complex navigation.]_
 
 ## Troubleshooting / FAQ
 - **Why isn't my module appearing in DevView?**

--- a/docs/modules/featureflip.md
+++ b/docs/modules/featureflip.md
@@ -2,8 +2,6 @@
 
 A Kotlin Multiplatform library for managing feature flags (feature toggles) with a built-in UI for toggling and managing features at runtime.
 
-> _[Placeholder: Insert screenshot of FeatureFlip UI. Use a device frame if relevant.]_
-
 ## Overview
 FeatureFlip enables runtime control of feature flags for development, QA, and experimentation. It supports both local and remote features, persistent state, and a ready-to-use Compose UI.
 
@@ -49,10 +47,10 @@ val newCheckout = Feature.RemoteFeature(
 
 ### Using the UI
 ```kotlin
-CompositionLocalProvider(LocalFeatures provides features) {
-    FeatureFlipScreen(onStateChange = { featureName, newState ->
-        // Handle state change
-    })
+val featureHandler = rememberFeatureHandler(features)
+CompositionLocalProvider(LocalFeatureHandler provides featureHandler) {
+    // FeatureFlipScreen is rendered automatically by DevView when FeatureFlip is registered.
+    // State changes are handled internally by the DevView UI.
 }
 ```
 
@@ -60,12 +58,6 @@ CompositionLocalProvider(LocalFeatures provides features) {
 - Use `FeatureHandler` to manage features programmatically.
 - Use `FeatureFlipScreen` for a ready-made UI.
 - Features are persisted using DataStore.
-
-## Customisation
-> _[Placeholder: Guide for customising FeatureFlip UI and behaviour. This section will be expanded in future updates.]_
-
-## Advanced Usage
-> _[Placeholder: Advanced scenarios such as remote config integration, tri-state features, and platform-specific customisation.]_
 
 ## Best Practices
 1. Use descriptive names and add descriptions.

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -2,8 +2,6 @@
 
 DevView uses a modular architecture where each module provides specific developer tools functionality. Modules are plug-and-play and integrate seamlessly with the DevView core. You can include only the modules you need, and modules can be conditionally enabled based on build type, feature flags, or other criteria.
 
-> _[Placeholder: Insert screenshot of module selection UI. Use a device frame if relevant.]_
-
 ## Available Modules
 
 | Module         | Purpose/Features                                                                 | Link                       |

--- a/docs/modules/networkmock-core.md
+++ b/docs/modules/networkmock-core.md
@@ -1,37 +1,94 @@
 # NetworkMock Core
 
-The core module (`devview-networkmock-core`) provides shared logic and persistent storage for network mocking.
+The `devview-networkmock-core` module is the shared engine for network mocking. It owns JSON config parsing, request matching, response file discovery, and DataStore state persistence. Both `devview-networkmock` (UI) and `devview-networkmock-ktor` (Ktor plugin) depend on it — it exists specifically to let those two modules share state without depending on each other.
 
-## Overview
-- Stores mock configuration and state using a process-level DataStoreDelegate.
-- Exposes repositories for managing mock settings and responses.
-- Ensures consistent access to configuration/state across UI and Ktor plugin modules.
+## mocks.json Format
 
-## Features
-- Singleton DataStore for storing preferences
-- Singleton object for initializing and exposing repositories
-- Repository pattern for configuration/state
+Place at `composeResources/files/networkmocks/mocks.json`:
 
-## Usage
-- Initialize the core module before using UI or Ktor plugin.
-- Access repositories via `NetworkMockInitializer`.
-- DataStoreDelegate ensures all modules operate on the same data.
+```json
+{
+  "apiGroups": [
+    {
+      "id": "my-backend",
+      "name": "My Backend",
+      "endpoints": [
+        { "id": "getUser", "name": "Get User", "path": "/v1/users/{userId}", "method": "GET" }
+      ],
+      "environments": [
+        {
+          "id": "staging",
+          "name": "Staging",
+          "url": "https://staging.api.example.com"
+        },
+        {
+          "id": "production",
+          "name": "Production",
+          "url": "https://api.example.com",
+          "endpointOverrides": [
+            { "id": "getUser", "path": "/v2/users/{userId}" }
+          ],
+          "additionalEndpoints": [
+            { "id": "getLegacy", "name": "Legacy", "path": "/users", "method": "GET" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
 
-## Best Practices
-- Always initialize the core before using UI or Ktor plugin.
-- Use the provided repositories for all configuration/state changes.
+Key concepts:
+- **`apiGroups`**: Logical backends, each with shared endpoints and multiple environments.
+- **`endpointOverrides`**: Per-environment path overrides for specific endpoint IDs.
+- **`additionalEndpoints`**: Endpoints that only exist in a specific environment.
+- **`{param}` placeholders**: Path segments like `{userId}` match any value during request matching.
 
-## Troubleshooting / FAQ
-- **Why aren't my mocks persisting?**
-  - Ensure you are using the shared DataStoreDelegate and not a separate instance.
-- **How do I reset all state?**
-  - Use repository methods to clear or reset configuration/state.
+## Request Matching
+
+`MockConfigRepository.findMatchingMock(host, path, method)` resolves a mock in three steps:
+
+1. **Hostname match** — extracts the hostname from each `EnvironmentConfig.url` (strips scheme, port, path), compares case-insensitively against the incoming request host.
+2. **Path match** — splits path by `/`, compares segment by segment; `{param}` segments match any value; non-param segments are case-sensitive.
+3. **Method match** — case-sensitive exact match. Use uppercase (`"GET"`, `"POST"`).
+
+There is no stored active-environment selection. The environment is determined purely from the request hostname at interception time, allowing simultaneous requests to multiple environments across groups.
+
+## Response File Discovery
+
+Response files live under `composeResources/files/networkmocks/responses/`:
+
+```
+responses/{groupId}/{environmentId}/{endpointId}/{endpointId}-{status}[-{suffix}].json  ← highest priority
+responses/{groupId}/{endpointId}/{endpointId}-{status}[-{suffix}].json                  ← shared fallback
+```
+
+The core module probes the following status codes by default: `200, 201, 202, 204, 400, 401, 403, 404, 409, 422, 429, 500, 502, 503, 504`.
+
+Default suffixes: `""`, `"-simple"`, `"-detailed"`, `"-error"`, `"-success"`.
+
+If your API uses status codes outside the defaults, pass a custom list:
+
+```kotlin
+MockConfigRepository(
+    resourceLoader = { path -> Res.readBytes(path) },
+    statusCodesToDiscover = listOf(200, 400, 503, 418)
+)
+```
+
+## DataStore Schema
+
+State is persisted via `MockStateRepository`:
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `network_mock_global_enabled` | Boolean | Master toggle |
+| `network_mock_last_modified` | Long | Epoch ms of last change |
+| `network_mock_endpoint_{compositeKey}` | String (JSON) | Per-endpoint state |
+
+`EndpointMockState` is serialized as `{"type":"network"}` (pass-through) or `{"type":"mock","responseFile":"getUser-200.json"}`.
 
 ## Related Modules
-- [NetworkMock](networkmock.md): Overview and usage.
-- [NetworkMock UI](networkmock-ui.md): UI for managing mocks.
-- [NetworkMock Ktor](networkmock-ktor.md): Ktor plugin for HTTP interception.
 
----
-
-*API reference is available via Dokka or in your IDE.*
+- [NetworkMock](networkmock.md): UI layer and module entry point.
+- [NetworkMock Ktor](networkmock-ktor.md): Ktor client plugin.

--- a/docs/modules/networkmock-ktor.md
+++ b/docs/modules/networkmock-ktor.md
@@ -1,48 +1,59 @@
 # NetworkMock Ktor Plugin
 
-The Ktor plugin module (`devview-networkmock-ktor`) enables network mocking for HTTP requests in Ktor clients.
+The `devview-networkmock-ktor` module is a Ktor `HttpClientPlugin` that intercepts outgoing HTTP requests and returns in-memory mock responses. It delegates all config and state lookups to `devview-networkmock-core` and has no UI.
 
-## Overview
-- Intercepts HTTP requests and returns mock responses based on configuration.
-- Reads configuration/state from the core module.
-- Supports flexible mock setup for development and testing.
+## Installation
 
-## Features
-- Ktor client plugin for HTTP interception
-- Reads configuration/state from the core module
-- Supports flexible mock setup for development and testing
+### Zero-config (recommended)
 
-## Usage
-- Install the plugin in your Ktor client configuration.
-- Ensure core module is initialized and accessible.
-- Configure mock endpoints and responses via UI or programmatically.
+When `NetworkMock` is registered via `rememberModules`, the plugin resolves its repositories automatically:
 
-### Example
 ```kotlin
-val client = HttpClient {
+// Register the NetworkMock module in your app
+val modules = rememberModules {
+    module(NetworkMock(resourceLoader = { path -> Res.readBytes(path) }))
+}
+
+// Install the plugin in your Ktor client — no configuration needed
+val client = HttpClient(OkHttp) {
+    install(NetworkMockPlugin)
+}
+```
+
+`rememberModules { }` must be called (and composed) before any request reaches the network layer.
+
+### Explicit repository injection (for tests or advanced DI)
+
+```kotlin
+val client = HttpClient(OkHttp) {
     install(NetworkMockPlugin) {
-        config = ... // Provide NetworkMockConfig
+        mockRepository = myMockConfigRepository
+        stateRepository = myMockStateRepository
     }
 }
 ```
 
-## Best Practices
-- Ensure the core module is initialized before using the plugin.
-- Keep mock configuration up-to-date for accurate testing.
-- Use the UI for easy management of mocks.
+## How Interception Works
 
-## Troubleshooting / FAQ
-- **Why isn't my mock being applied?**
-  - Ensure the plugin is installed and configuration matches the endpoint.
-- **How do I reset all mocks?**
-  - Use the UI reset option or reset state via the core repository.
+For every outgoing request, the plugin:
+
+1. Calls `stateRepository.getState()` to read the current mock state.
+2. If `globalMockingEnabled` is `false` → sends the real request.
+3. Calls `mockRepository.findMatchingMock(host, path, method)`.
+4. If no match → sends the real request.
+5. If matched, reads the endpoint's `EndpointMockState`:
+   - `Network` or `null` → sends the real request.
+   - `Mock(responseFile)` → loads the response file and returns a synthetic response.
+6. On any error (missing file, malformed name, exception) → falls back to the real network and logs the reason. **The plugin never throws.**
+
+Mock responses are returned with HTTP/1.1 status, an empty header set, and the file contents as the body.
+
+## Platform Actuals
+
+- **Android**: Use `HttpClient(OkHttp)` as the engine.
+- **iOS**: Use `HttpClient(Darwin)` as the engine.
 
 ## Related Modules
-- [NetworkMock](networkmock.md): Overview and usage.
-- [NetworkMock Core](networkmock-core.md): Shared configuration/state.
-- [NetworkMock UI](networkmock-ui.md): UI for managing mocks.
-- [FeatureFlip](featureflip.md): Combine with feature flags for advanced testing.
 
----
-
-*API reference is available via Dokka or in your IDE.*
+- [NetworkMock](networkmock.md): UI layer and module entry point.
+- [NetworkMock Core](networkmock-core.md): Config parsing, request matching, and state.

--- a/docs/modules/networkmock-ui.md
+++ b/docs/modules/networkmock-ui.md
@@ -1,39 +1,39 @@
 # NetworkMock UI
 
-The UI module (`devview-networkmock`) provides Compose screens and controls for managing network mocks.
+The `devview-networkmock` module provides the Compose UI for the network mocking feature. It implements the `Module` interface and surfaces two navigation screens backed by `devview-networkmock-core`.
 
-## Overview
-- Toggle global mocking on/off
-- Enable/disable individual endpoint mocks
-- Select mock responses for each endpoint
-- Reset all mocks to use actual network
+## Screens
 
-## Features
-- Compose UI for managing mocks
-- Viewmodels and components for endpoint management
-- Interacts with core repositories to update configuration/state
+### Main screen — endpoint list
 
-## Usage
-- Add the NetworkMock screen to your Compose navigation.
-- Use provided viewmodels and components for endpoint management.
-- UI changes are reflected in the Ktor plugin via shared state.
+The main screen shows a global mock toggle at the top, followed by a scrollable tab row with one tab per API group + environment combination (e.g. "My Backend – Staging"). Each tab lists the endpoints for that group/environment with their current mock state.
 
-## Best Practices
-- Extend or modify UI components for custom mock management.
-- Integrate with other DevView modules as needed.
+- **Global toggle**: enables or disables all mocking globally. When off, all requests go to the real network regardless of per-endpoint settings.
+- **Endpoint cards**: show the endpoint name, HTTP method, path, and current state chip (Network / HTTP status code). Tap an endpoint to open its detail screen.
+- **Reset to Network**: toolbar action that resets every endpoint to `Network` state in one tap.
 
-## Troubleshooting / FAQ
-- **Why aren't my UI changes reflected in the Ktor plugin?**
-  - Ensure both modules use the same DataStoreDelegate and core initialization.
-- **How do I reset all mocks?**
-  - Use the UI reset option or clear state via the core repository.
+### Endpoint detail screen
+
+Shows the full endpoint info and all discovered mock response files, grouped by status code family (2xx, 4xx, 5xx, etc.).
+
+- **"No mock" option**: tap to route this endpoint to the real network.
+- **Response items**: tap to activate a mock response (shown with its status code chip); long-press to open a preview bottom sheet.
+- **Preview bottom sheet**: shows the response file contents. Long-press a second response to enter compare mode, which renders a side-by-side or inline diff (LCS-based, collapses long unchanged runs).
+
+## Registration
+
+```kotlin
+val modules = rememberModules {
+    module(NetworkMock(
+        resourceLoader = { path -> Res.readBytes(path) }
+    ))
+}
+```
+
+`configPath` defaults to `"files/networkmocks/mocks.json"`. Pass a custom value if your config lives elsewhere.
 
 ## Related Modules
-- [NetworkMock](networkmock.md): Overview and usage.
-- [NetworkMock Core](networkmock-core.md): Shared configuration/state.
-- [NetworkMock Ktor](networkmock-ktor.md): Ktor plugin for HTTP interception.
-- [FeatureFlip](featureflip.md): Combine with feature flags for advanced testing.
 
----
-
-*API reference is available via Dokka or in your IDE.*
+- [NetworkMock Core](networkmock-core.md): Shared config and state.
+- [NetworkMock Ktor](networkmock-ktor.md): Ktor client plugin.
+- [NetworkMock Workflows](networkmock-workflows.md): Step-by-step integration guide.

--- a/docs/modules/networkmock-workflows.md
+++ b/docs/modules/networkmock-workflows.md
@@ -1,46 +1,90 @@
 # NetworkMock Workflows
 
-This page covers common developer workflows for integrating and using the NetworkMock modules.
+Step-by-step guides for common network mocking tasks.
 
-## Overview
-NetworkMock supports a variety of workflows for mocking network requests, managing configuration, and integrating with UI and Ktor plugin.
+## Adding a new mock endpoint
 
-## Workflows
-### Adding a New Mock Endpoint
-1. Define the endpoint in the core module's configuration.
-2. Update the UI to display and manage the new endpoint.
-3. Configure mock responses as needed.
+### 1. Add the endpoint to mocks.json
 
-### Enabling/Disabling Mocks
-- Use the UI toggle to enable/disable global or per-endpoint mocking.
-- Update state via repositories for programmatic control.
+```json
+{
+  "apiGroups": [{
+    "id": "my-backend",
+    "name": "My Backend",
+    "endpoints": [
+      { "id": "getUser", "name": "Get User", "path": "/v1/users/{userId}", "method": "GET" }
+    ],
+    "environments": [
+      { "id": "staging", "name": "Staging", "url": "https://staging.api.example.com" }
+    ]
+  }]
+}
+```
 
-### Resetting Mocks
-- Use the UI reset option to revert all endpoints to real network behavior.
-- Alternatively, reset state via core repositories.
+### 2. Create response files
 
-### Integrating UI and Ktor Plugin
-- Ensure both modules reference the same DataStoreDelegate.
-- UI changes are reflected in Ktor plugin behavior automatically.
+Place response files under `composeResources/files/networkmocks/responses/`:
 
-## Best Practices
-- Initialize core module before using UI or Ktor plugin.
-- Keep mock configuration up-to-date for accurate testing.
-- Use workflows to streamline development and testing.
+```
+responses/my-backend/getUser/getUser-200.json      ← shared (all environments)
+responses/my-backend/staging/getUser/getUser-200.json  ← staging-specific (takes priority)
+```
 
-## Troubleshooting / FAQ
-- **Why aren't my workflow changes reflected in the app?**
-  - Ensure all modules are referencing the same core and DataStoreDelegate.
-- **How do I debug mock configuration issues?**
-  - Use the UI to inspect and update configuration/state.
+File naming: `{endpointId}-{statusCode}[-{suffix}].json`
+
+```
+getUser-200.json         ← default 200 response
+getUser-200-simple.json  ← alternate 200 response (simple variant)
+getUser-404.json         ← 404 error response
+getUser-500.json         ← server error response
+```
+
+### 3. Launch the app
+
+Open DevView → Network Mock. Your new endpoint appears in the list for its group/environment tab.
+
+## Testing an error scenario
+
+1. Open DevView → Network Mock → tap your endpoint.
+2. Tap a 4xx or 5xx response file to activate it.
+3. The endpoint chip turns red/orange. The Ktor plugin now returns that response for matching requests.
+4. After testing, tap "No mock" or use the "Reset to Network" toolbar action to restore pass-through.
+
+## Using environment-specific responses
+
+To serve a different response for production vs staging, place environment-specific files at higher priority:
+
+```
+responses/my-backend/getUser/getUser-200.json          ← shared fallback
+responses/my-backend/production/getUser/getUser-200.json  ← production-specific
+```
+
+The environment is determined at interception time from the request hostname — no manual selection needed.
+
+## Using endpoint path overrides per environment
+
+In `mocks.json`, add `endpointOverrides` to a specific environment:
+
+```json
+{
+  "id": "production",
+  "url": "https://api.example.com",
+  "endpointOverrides": [
+    { "id": "getUser", "path": "/v2/users/{userId}" }
+  ]
+}
+```
+
+The production environment now uses `/v2/users/{userId}` for `getUser` while staging keeps `/v1/users/{userId}`.
+
+## Resetting all mocks
+
+- **UI**: Open DevView → Network Mock → tap the restore icon in the top toolbar.
+- **All mocks are reset to `Network` state**, including endpoints the user has never explicitly touched.
 
 ## Related Modules
-- [NetworkMock](networkmock.md): Overview and usage.
-- [NetworkMock Core](networkmock-core.md): Shared configuration/state.
-- [NetworkMock UI](networkmock-ui.md): UI for managing mocks.
-- [NetworkMock Ktor](networkmock-ktor.md): Ktor plugin for HTTP interception.
-- [FeatureFlip](featureflip.md): Combine with feature flags for advanced testing.
 
----
-
-*API reference is available via Dokka or in your IDE.*
+- [NetworkMock](networkmock.md): Overview and installation.
+- [NetworkMock Core](networkmock-core.md): Config format details, request matching.
+- [NetworkMock UI](networkmock-ui.md): Screen descriptions.
+- [NetworkMock Ktor](networkmock-ktor.md): Plugin installation.

--- a/docs/modules/networkmock.md
+++ b/docs/modules/networkmock.md
@@ -2,8 +2,6 @@
 
 A Kotlin Multiplatform library for mocking network requests and responses, with a built-in UI and Ktor plugin for flexible development and testing.
 
-> _[Placeholder: Insert screenshot of NetworkMock UI. Use a device frame if relevant.]_
-
 ## Overview
 NetworkMock enables developers to simulate API behaviour, test offline flows, and control network responses at runtime. It consists of three modules:
 - **Core**: Shared configuration and state management
@@ -30,7 +28,9 @@ dependencies {
 Add NetworkMock to your DevView modules list:
 ```kotlin
 val modules = rememberModules {
-    module(NetworkMock)
+    module(NetworkMock(
+        resourceLoader = { path -> Res.readBytes(path) }
+    ))
     // ...other modules...
 }
 ```
@@ -43,9 +43,16 @@ NetworkMockScreen(...)
 ```
 ### Using the Ktor Plugin
 ```kotlin
-val client = HttpClient {
+// Zero-config: repositories are resolved automatically from NetworkMockInitializer
+val client = HttpClient(OkHttp) {
+    install(NetworkMockPlugin)
+}
+
+// For testing or advanced DI, inject repositories explicitly:
+val client = HttpClient(OkHttp) {
     install(NetworkMockPlugin) {
-        config = ... // Provide NetworkMockConfig
+        mockRepository = myMockConfigRepository
+        stateRepository = myMockStateRepository
     }
 }
 ```
@@ -54,12 +61,6 @@ val client = HttpClient {
 - Use the UI to toggle mocks and select responses.
 - Use the Ktor plugin to intercept requests in your client.
 - Configuration/state is shared via the core module.
-
-## Customisation
-> _[Placeholder: Guide for customising NetworkMock UI and behaviour. This section will be expanded in future updates.]_
-
-## Advanced Usage
-> _[Placeholder: Advanced scenarios such as workflows, custom mock engines, and platform-specific customisation.]_
 
 ## Best Practices
 1. Initialise the core module before using UI or Ktor plugin.

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -8,4 +8,7 @@ cp -r internal/dokka/build/dokka/html/ docs/api/
 
 cp CHANGELOG.md docs/changelog.md
 
+DEVVIEW_VERSION=$(grep "^VERSION_NAME=" gradle.properties | cut -d'=' -f2 | sed 's/-SNAPSHOT//')
+find docs -name "*.md" -exec sed -i "s/DEVVIEW_VERSION/$DEVVIEW_VERSION/g" {} \;
+
 zensical $@ --clean


### PR DESCRIPTION
- Add docs build commands and internal/dokka to CLAUDE.md module graph
- Fix incorrect API examples across all doc pages (AnalyticsLogType hierarchy, Module interface types, Section enum, FeatureFlipScreen signature, NetworkMockPlugin DSL, registerSerializers typo)
- Fill out thin NetworkMock doc pages with real content (mocks.json format, request matching, response discovery, interception flow, workflows)
- Strip all placeholder markers from ~30 docs pages
- Inject version from gradle.properties at docs build time via build_docs.sh so installation guide always reflects the release being published
- Create 8 GitHub issues (#49-56) tracking NetworkMock improvements and test gaps