### PR TITLE
fix: synchronously kill crashpad_handler after device tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,10 +245,10 @@ jobs:
           force-avd-creation: ${{ matrix.force-avd-creation }}
           emulator-options: ${{ matrix.test-emulator-options }}
           disable-animations: false
-          script: >-
-            trap '(sleep 30; while pgrep -x crashpad_handler >/dev/null 2>&1; do echo "crashpad_handler:
-            still running, killing"; pkill -9 crashpad_handler || true; sleep 5; done; echo "crashpad_handler: gone") &' EXIT;
-            ./gradlew connectedDebugAndroidTest -Pandroidx.baselineprofile.skipgeneration
+          script: |
+            ./gradlew connectedDebugAndroidTest -Pandroidx.baselineprofile.skipgeneration || GRADLE_EXIT=$?
+            pkill -9 crashpad_handler 2>/dev/null || true
+            exit ${GRADLE_EXIT:-0}
 
       - name: Upload device test reports
         if: failure()

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -10,8 +10,23 @@ How to submit pull requests to DevView.
 - Review your changes for clarity and completeness
 - Update documentation if needed
 
+## PR Title
+
+PR titles **must** follow `type: description` format — this is enforced by CI (`semantic-title` job):
+
+```
+feat: add network mock response editor
+fix: correct overlay back navigation
+docs: update installation guide
+refactor: remove dead endpoint selection state
+```
+
+Valid types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `perf`, `build`, `revert`.
+
+GitHub auto-suggests a title from the branch name — always verify it matches this format before opening the PR.
+
 ## Opening a Pull Request
-- Use a clear, descriptive title and summary
+- Use a clear, descriptive title (see above) and summary
 - Reference related issues or discussions
 - Assign reviewers if possible
 - Mark as draft if not ready for review
@@ -32,13 +47,17 @@ How to submit pull requests to DevView.
 - refactor/description - Refactoring
 
 ## Commit Messages
-Follow conventional commits:
+
+Individual commits use **gitmoji** format: `:emoji: message`
+
 ```
-feat: add new module
-fix: correct navigation issue
-docs: update README
-refactor: improve code structure
+:sparkles: Add network mock response editor
+:bug: Fix overlay back navigation
+:memo: Update installation guide
+:fire: Remove dead endpoint selection code
 ```
+
+Note: PRs are squash-merged using the PR title (`type: description`) as the final commit message. The gitmoji format is for individual commits on your branch.
 
 ## Checklist
 - [ ] Tests pass


### PR DESCRIPTION
## Summary

- Replace the deferred background trap with a synchronous `pkill -9 crashpad_handler` that runs immediately after Gradle exits
- The old approach backgrounded a killer with a 30s delay, which raced with the action's cleanup and sometimes lost
- Also fixes the PR title/commit message conventions in `docs/contributing/pull-requests.md` (placeholder content was inaccurate)

## Root cause

`crashpad_handler` (Chromium's crash reporter, shipped with WebView) keeps the emulator process alive after tests complete. The `android-emulator-runner` action's cleanup waits for the emulator to exit — blocking forever.

## Test plan

- [ ] Observe the API 29 `device-tests` job: after Gradle finishes, the step should exit cleanly instead of hanging
- [ ] If the job stalls *during* boot (emulator never starts), that's the unrelated upstream runner image issue [android-emulator-runner#478](https://github.com/ReactiveCircus/android-emulator-runner/issues/478) — out of scope

🤖 Generated with [Claude Code](https://claude.ai/claude-code)