### PR TITLE
feat: add NetworkMockResourceLoader fun interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `NetworkMockResourceLoader` fun interface in `devview-networkmock-core`: provides a named type for DI frameworks (Koin, Hilt, etc.) to bind, eliminating the need for a custom bridge interface in multi-module KMP projects where mock resource files live in a different module than where `NetworkMock` is constructed. Both `devview-networkmock` and `devview-networkmock-ktor` now expose `devview-networkmock-core` as an `api` dependency so the type is available to all integrators.
+
 ### Fixed
 - Fixed DevView overlay back navigation: the overlay's back handler now correctly yields priority to the host app when closed, preventing it from silently consuming back events.
 - Fixed crash on Network Mock screen startup: `MissingResourceException` thrown by Compose Resources when probing absent response files was not caught by the `IllegalStateException` handler in `MockConfigRepository`, causing a fatal crash. The exception is now normalised at the `NetworkMock` boundary before reaching the core module.

--- a/devview-networkmock-core/src/commonMain/kotlin/com/worldline/devview/networkmock/core/NetworkMockInitializer.kt
+++ b/devview-networkmock-core/src/commonMain/kotlin/com/worldline/devview/networkmock/core/NetworkMockInitializer.kt
@@ -50,15 +50,14 @@ public object NetworkMockInitializer {
      * @param dataStore The initialised [DataStore] instance from [NetworkMockDataStoreDelegate]
      * @param configPath Path to the `mocks.json` configuration file relative to
      * composeResources (e.g. `"files/networkmocks/mocks.json"`)
-     * @param resourceLoader Function to load resource bytes from a path, provided
-     * by the integrator's resource system (e.g. `Res.readBytes` from Compose Resources)
+     * @param resourceLoader [NetworkMockResourceLoader] provided by the integrator
      */
     @Suppress("ComposableNaming")
     @Composable
     public fun initialize(
         dataStore: DataStore<Preferences>,
         configPath: String,
-        resourceLoader: suspend (String) -> ByteArray
+        resourceLoader: NetworkMockResourceLoader
     ) {
         if (stateRepository != null) return
         stateRepository = remember {

--- a/devview-networkmock-core/src/commonMain/kotlin/com/worldline/devview/networkmock/core/NetworkMockResourceLoader.kt
+++ b/devview-networkmock-core/src/commonMain/kotlin/com/worldline/devview/networkmock/core/NetworkMockResourceLoader.kt
@@ -1,0 +1,24 @@
+package com.worldline.devview.networkmock.core
+
+/**
+ * Functional interface for loading resource bytes from a path.
+ *
+ * Implement this to bridge your module's Compose Resources to the network mock engine:
+ * ```kotlin
+ * NetworkMock(resourceLoader = NetworkMockResourceLoader { path -> Res.readBytes(path) })
+ * ```
+ *
+ * With a DI framework, register an implementation in the module that owns the mock files and
+ * inject it where `NetworkMock` is constructed:
+ * ```kotlin
+ * // In your data module's DI setup:
+ * single<NetworkMockResourceLoader> { NetworkMockResourceLoader { Res.readBytes(it) } }
+ *
+ * // In your presentation module:
+ * val loader = koinInject<NetworkMockResourceLoader>()
+ * NetworkMock(resourceLoader = loader)
+ * ```
+ */
+public fun interface NetworkMockResourceLoader {
+    public suspend fun load(path: String): ByteArray
+}

--- a/devview-networkmock-core/src/commonMain/kotlin/com/worldline/devview/networkmock/core/repository/MockConfigRepository.kt
+++ b/devview-networkmock-core/src/commonMain/kotlin/com/worldline/devview/networkmock/core/repository/MockConfigRepository.kt
@@ -1,5 +1,6 @@
 package com.worldline.devview.networkmock.core.repository
 
+import com.worldline.devview.networkmock.core.NetworkMockResourceLoader
 import com.worldline.devview.networkmock.core.model.EndpointKey
 import com.worldline.devview.networkmock.core.model.MockConfiguration
 import com.worldline.devview.networkmock.core.model.MockMatch
@@ -103,7 +104,7 @@ import kotlinx.serialization.json.Json
  * - [discoverResponseFiles] returns empty list if no files are found
  *
  * @property configPath The path to the mocks.json file relative to composeResources
- * @property resourceLoader Function to load resource bytes from a path
+ * @property resourceLoader [NetworkMockResourceLoader] that provides resource bytes from a path
  * @property statusCodesToDiscover The list of HTTP status codes to probe when
  * discovering response files. Defaults to [DEFAULT_STATUS_CODES]. Override this
  * to include non-standard status codes used by your API.
@@ -114,7 +115,7 @@ import kotlinx.serialization.json.Json
  */
 public class MockConfigRepository(
     private val configPath: String,
-    private val resourceLoader: suspend (String) -> ByteArray,
+    private val resourceLoader: NetworkMockResourceLoader,
     private val statusCodesToDiscover: List<Int> = DEFAULT_STATUS_CODES
 ) {
     private val json = Json { ignoreUnknownKeys = true }
@@ -195,7 +196,7 @@ public class MockConfigRepository(
 
             println(message = "[NetworkMock][Config] Loading configuration from: $configPath")
 
-            val configBytes = resourceLoader(configPath)
+            val configBytes = resourceLoader.load(path = configPath)
             val configJson = configBytes.decodeToString()
 
             val config = json
@@ -560,7 +561,7 @@ public class MockConfigRepository(
         filePath: String,
         fileName: String
     ): MockResponse? = try {
-        val responseBytes = resourceLoader(filePath)
+        val responseBytes = resourceLoader.load(path = filePath)
         val content = responseBytes.decodeToString()
         MockResponse.Companion
             .fromFile(

--- a/devview-networkmock-core/src/commonTest/kotlin/com/worldline/devview/networkmock/core/repository/MockConfigRepositoryTest.kt
+++ b/devview-networkmock-core/src/commonTest/kotlin/com/worldline/devview/networkmock/core/repository/MockConfigRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.worldline.devview.networkmock.core.repository
 
+import com.worldline.devview.networkmock.core.NetworkMockResourceLoader
 import com.worldline.devview.networkmock.core.model.EndpointKey
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactly
@@ -31,7 +32,7 @@ class MockConfigRepositoryTest {
         val loader = RecordingResourceLoader(resources = baseResources())
         val repository = MockConfigRepository(
             configPath = CONFIG_PATH,
-            resourceLoader = loader::load
+            resourceLoader = loader
         )
 
         repository.loadConfiguration().getOrThrow()
@@ -319,17 +320,17 @@ class MockConfigRepositoryTest {
         val loader = RecordingResourceLoader(resources = resources)
         return MockConfigRepository(
             configPath = CONFIG_PATH,
-            resourceLoader = loader::load,
+            resourceLoader = loader,
             statusCodesToDiscover = statusCodesToDiscover
         )
     }
 
     private class RecordingResourceLoader(
         private val resources: Map<String, String>
-    ) {
+    ) : NetworkMockResourceLoader {
         private val calls = mutableMapOf<String, Int>()
 
-        suspend fun load(path: String): ByteArray {
+        override suspend fun load(path: String): ByteArray {
             calls[path] = (calls[path] ?: 0) + 1
             return resources[path]?.encodeToByteArray()
                 ?: error("Resource not found: $path")

--- a/devview-networkmock-ktor/build.gradle.kts
+++ b/devview-networkmock-ktor/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(projects.devviewNetworkmockCore)
+                api(projects.devviewNetworkmockCore)
             }
         }
 

--- a/devview-networkmock/build.gradle.kts
+++ b/devview-networkmock/build.gradle.kts
@@ -20,7 +20,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(projects.devview)
-                implementation(projects.devviewNetworkmockCore)
+                api(projects.devviewNetworkmockCore)
                 implementation(libs.kotlinx.collections.immutable)
                 implementation(libs.jetbrains.androidx.lifecycle.viewmodel.compose)
             }

--- a/devview-networkmock/src/commonMain/kotlin/com/worldline/devview/networkmock/NetworkMock.kt
+++ b/devview-networkmock/src/commonMain/kotlin/com/worldline/devview/networkmock/NetworkMock.kt
@@ -16,6 +16,7 @@ import com.worldline.devview.core.withTitle
 import com.worldline.devview.networkmock.core.NETWORK_MOCK_DATASTORE_NAME
 import com.worldline.devview.networkmock.core.NetworkMockDataStoreDelegate
 import com.worldline.devview.networkmock.core.NetworkMockInitializer
+import com.worldline.devview.networkmock.core.NetworkMockResourceLoader
 import com.worldline.devview.networkmock.core.model.EndpointKey
 import com.worldline.devview.networkmock.viewmodel.NetworkMockEndpointViewModel
 import com.worldline.devview.networkmock.viewmodel.NetworkMockViewModel
@@ -67,7 +68,7 @@ public sealed interface NetworkMockDestination : NavKey {
  * ```kotlin
  * val modules = rememberModules {
  *     module(NetworkMock(
- *         resourceLoader = { path -> Res.readBytes(path) }
+ *         resourceLoader = NetworkMockResourceLoader { path -> Res.readBytes(path) }
  *     ))
  * }
  * ```
@@ -79,13 +80,12 @@ public sealed interface NetworkMockDestination : NavKey {
  * }
  * ```
  *
- * @property resourceLoader Function to load resource bytes from a path, provided
- * by the integrator's resource system (e.g. `Res.readBytes` from Compose Resources)
+ * @property resourceLoader [NetworkMockResourceLoader] provided by the integrator's resource system
  * @property configPath Path to the `mocks.json` configuration file relative to
  * composeResources. Defaults to `"files/networkmocks/mocks.json"`.
  */
 public class NetworkMock(
-    private val resourceLoader: suspend (String) -> ByteArray,
+    private val resourceLoader: NetworkMockResourceLoader,
     private val configPath: String = "files/networkmocks/mocks.json"
 ) : Module,
     RequiresDataStore {
@@ -114,7 +114,7 @@ public class NetworkMock(
             configPath = configPath,
             resourceLoader = { path ->
                 try {
-                    resourceLoader(path)
+                    resourceLoader.load(path = path)
                 } catch (e: MissingResourceException) {
                     throw IllegalStateException(e.message, e)
                 }


### PR DESCRIPTION
## Summary

- Introduces `NetworkMockResourceLoader` fun interface in `devview-networkmock-core`, giving DI frameworks (Koin, Hilt, etc.) a named type to bind
- Switches `devview-networkmock` and `devview-networkmock-ktor` from `implementation` to `api` for `devview-networkmock-core`, so the type is transitively visible to all integrators
- Updates `MockConfigRepository`, `NetworkMockInitializer`, and `NetworkMock` to use the new type throughout; existing lambda call sites continue to work via SAM conversion

## Motivation

In multi-module KMP projects, Compose Resources are module-scoped. When mock files live in a different module (e.g. `data`) than where `NetworkMock` is constructed (e.g. `presentation`), integrators previously had to define their own bridge interface, implementation, and DI binding — 3 files. With `NetworkMockResourceLoader` available as a named type, that collapses to a single DI binding:

```kotlin
// Before (3 files across domain + data modules)
// After (1 binding in the data module):
single<NetworkMockResourceLoader> { NetworkMockResourceLoader { Res.readBytes(it) } }
```

## Test plan

- [x] `compileAndroidMain` clean on `-core` and `-networkmock`
- [x] Full test suite (`testAndroidHostTest`) passes — 284 tasks
- [x] `detektFull` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)