### PR TITLE
fix: crashpad_handler stall in API 29 device tests

### DIFF
--- a/.github/actions/get-avd-info/action.yml
+++ b/.github/actions/get-avd-info/action.yml
@@ -1,0 +1,19 @@
+name: 'Get AVD Info'
+description: 'Get the AVD arch and target based on its API level.'
+inputs:
+  api-level:
+    required: true
+outputs:
+  arch:
+    value: ${{ steps.get-avd-arch.outputs.arch }}
+  target:
+    value: ${{ steps.get-avd-target.outputs.target }}
+runs:
+  using: "composite"
+  steps:
+    - id: get-avd-arch
+      run: echo "arch=$(if [ ${{ inputs.api-level }} -ge 30 ]; then echo x86_64; else echo x86; fi)" >> $GITHUB_OUTPUT
+      shell: bash
+    - id: get-avd-target
+      run: echo "target=default" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,25 +178,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - api-level: 26
-            target: default
-            arch: x86
-            force-avd-creation: true
-            test-emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          - api-level: 29
-            target: default
-            arch: x86
-            force-avd-creation: false
-            test-emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          - api-level: 35
-            target: google_apis
-            arch: x86_64
-            force-avd-creation: false
-            test-emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        api-level: [26, 31, 36]
 
     steps:
       - uses: actions/checkout@v7
+
+      - name: Get AVD info
+        uses: ./.github/actions/get-avd-info
+        id: avd-info
+        with:
+          api-level: ${{ matrix.api-level }}
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v6
@@ -222,16 +213,15 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-v3-${{ runner.os }}-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}-anim-on-${{ hashFiles('.github/workflows/build.yml') }}
+          key: avd-v4-${{ runner.os }}-${{ matrix.api-level }}-${{ steps.avd-info.outputs.target }}-${{ steps.avd-info.outputs.arch }}-${{ hashFiles('.github/workflows/build.yml') }}
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.target }}
-          arch: ${{ matrix.arch }}
-          force-avd-creation: ${{ matrix.force-avd-creation }}
+          target: ${{ steps.avd-info.outputs.target }}
+          arch: ${{ steps.avd-info.outputs.arch }}
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
@@ -240,16 +230,11 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.target }}
-          arch: ${{ matrix.arch }}
-          force-avd-creation: ${{ matrix.force-avd-creation }}
-          emulator-options: ${{ matrix.test-emulator-options }}
+          target: ${{ steps.avd-info.outputs.target }}
+          arch: ${{ steps.avd-info.outputs.arch }}
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
-          script: >-
-            ./gradlew connectedDebugAndroidTest -Pandroidx.baselineprofile.skipgeneration;
-            GRADLE_EXIT=$?;
-            (while true; do pkill -9 crashpad_handler 2>/dev/null || true; sleep 2; done) &
-            exit $GRADLE_EXIT
+          script: ./gradlew connectedDebugAndroidTest -Pandroidx.baselineprofile.skipgeneration
 
       - name: Upload device test reports
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,10 +245,11 @@ jobs:
           force-avd-creation: ${{ matrix.force-avd-creation }}
           emulator-options: ${{ matrix.test-emulator-options }}
           disable-animations: false
-          script: |
-            ./gradlew connectedDebugAndroidTest -Pandroidx.baselineprofile.skipgeneration || GRADLE_EXIT=$?
-            pkill -9 crashpad_handler 2>/dev/null || true
-            exit ${GRADLE_EXIT:-0}
+          script: >-
+            ./gradlew connectedDebugAndroidTest -Pandroidx.baselineprofile.skipgeneration;
+            GRADLE_EXIT=$?;
+            (while true; do pkill -9 crashpad_handler 2>/dev/null || true; sleep 2; done) &
+            exit $GRADLE_EXIT
 
       - name: Upload device test reports
         if: failure()


### PR DESCRIPTION
## Summary

- Revert `script: |` back to `script: >-` (single folded line)
- Replace the one-shot `pkill` with a background loop that kills `crashpad_handler` continuously

## Root cause of the regression in #58

Two bugs were introduced:

**`script: |` breaks variable scoping.** `android-emulator-runner@v2` splits multiline scripts by newline and runs each line as a separate `sh -c`. `GRADLE_EXIT` set on line 1 is gone by line 3 — Gradle failures were silently masked (always exiting 0). The `>-` fold is required, not cosmetic.

**One-shot kill is too early.** The synchronous `pkill` ran before the action's own `adb emu kill`. That shutdown triggers a new `crashpad_handler` to spawn. The killer must run *throughout* the action's cleanup, not just once before it.

## What the fix does

```
./gradlew ...; GRADLE_EXIT=$?; (while true; do pkill -9 crashpad_handler ...; sleep 2; done) &; exit $GRADLE_EXIT
```

- Single line via `>-` → variables persist, Gradle exit code propagates
- Background killer loop → starts immediately after Gradle, survives script exit, keeps killing any `crashpad_handler` that appears during emulator shutdown
- Runner's own orphan cleanup terminates the loop when the job ends

## Test plan

- [ ] API 29 `device-tests` job completes without hanging after `BUILD SUCCESSFUL`
- [ ] A failing Gradle build still reports the job as failed (exit code not masked)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)