### PR TITLE
fix: delete_old_version_docs.sh shebang for ubuntu-latest

### DIFF
--- a/scripts/delete_old_version_docs.sh
+++ b/scripts/delete_old_version_docs.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 versions=($(mike list | tr ' ' '\n'))
 


### PR DESCRIPTION
## Summary

- Fixes `delete_old_version_docs.sh` failing on CI with "cannot execute: required file not found" because `#!/bin/zsh` is not available on ubuntu-latest
- Changed shebang to `#!/bin/bash`, which is always available and supports the `declare -A` and `sort -V` syntax used in the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)