### PR TITLE
fix: reduce excessive recompositions across Compose screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed excessive recompositions and broken Switch animation on `FeatureFlipScreen`: item keys now use the stable `feature.name` instead of `hashCode()`, `FeatureHandler` caches its Flow to prevent `collectAsStateWithLifecycle` from restarting on every recomposition, and redundant explicit `remember` keys have been removed from `derivedStateOf` blocks. (`devview-featureflip`)
+- Added `distinctUntilChanged()` to `FeatureHandler.isFeatureEnabledFlow` and `getFeatures` to suppress recompositions when DataStore emits structurally identical values. (`devview-featureflip`)
+- Fixed `AnalyticsScreen` `LazyColumn` using `log.hashCode()` as item key instead of the stable `log.timestamp`; removed redundant explicit keys from all `derivedStateOf` blocks. (`devview-analytics`)
+- Fixed `HomeScreen` `LazyColumn` using `module.hashCode()` as item key instead of the stable `module.moduleName`. (`devview`)
+- Fixed `NetworkMockScreen` using `collectAsState()` instead of `collectAsStateWithLifecycle()`, causing unnecessary state collection when the screen is off-stack or the app is backgrounded. (`devview-networkmock`)
+- Added `distinctUntilChanged()` to `MockStateRepository.observeState()` to suppress recompositions triggered by structurally equal `NetworkMockState` emissions from DataStore. (`devview-networkmock-core`)
+
 ## [0.1.3] - 2026-07-21
 
 ### Added

--- a/devview-analytics/src/commonMain/kotlin/com/worldline/devview/analytics/AnalyticsScreen.kt
+++ b/devview-analytics/src/commonMain/kotlin/com/worldline/devview/analytics/AnalyticsScreen.kt
@@ -133,7 +133,7 @@ public fun AnalyticsScreen(
     val lazyListState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
 
-    val showScrollToTopFab by remember(key1 = lazyListState) {
+    val showScrollToTopFab by remember {
         derivedStateOf {
             val layoutInfo = lazyListState.layoutInfo
             val headerItem =
@@ -153,18 +153,13 @@ public fun AnalyticsScreen(
         targetValue = if (filtersExpanded) 180f else 0f
     )
 
-    val availableCategories by remember(key1 = analytics) {
+    val availableCategories by remember {
         derivedStateOf {
             analytics.map { it.type.category }.distinct()
         }
     }
 
-    val filteredAnalytics by remember(
-        analytics,
-        filterQuery,
-        selectedCategories,
-        selectedTimeRange
-    ) {
+    val filteredAnalytics by remember {
         derivedStateOf {
             val now = Clock.System.now().toEpochMilliseconds()
             analytics.filter {
@@ -181,10 +176,7 @@ public fun AnalyticsScreen(
         }
     }
 
-    val highlightedAnalyticsLogs: PersistentList<HighlightedAnalyticsLog> by remember(
-        key1 = analytics,
-        key2 = highlightedAnalyticsLogTypes
-    ) {
+    val highlightedAnalyticsLogs: PersistentList<HighlightedAnalyticsLog> by remember {
         derivedStateOf {
             buildList {
                 add(element = HighlightedAnalyticsLog.Total(count = analytics.size))
@@ -396,7 +388,7 @@ public fun AnalyticsScreen(
             }
             itemsIndexed(
                 items = filteredAnalytics,
-                key = { _, log -> log.hashCode() }
+                key = { _, log -> log.timestamp }
             ) { index, log ->
                 Column(
                     modifier = Modifier

--- a/devview-featureflip/src/commonMain/kotlin/com/worldline/devview/featureflip/FeatureFlipScreen.kt
+++ b/devview-featureflip/src/commonMain/kotlin/com/worldline/devview/featureflip/FeatureFlipScreen.kt
@@ -120,7 +120,7 @@ import kotlinx.coroutines.launch
 @Composable
 public fun FeatureFlipScreen(modifier: Modifier = Modifier, bottomPadding: Dp = 0.dp) {
     val featureHandler = LocalFeatureHandler.current
-    val features by featureHandler.features
+    val featuresState = featureHandler.features
 
     @Suppress("InjectDispatcher")
     val coroutineScope = rememberCoroutineScope(getContext = { Dispatchers.IO })
@@ -130,13 +130,14 @@ public fun FeatureFlipScreen(modifier: Modifier = Modifier, bottomPadding: Dp = 
 
     val selectedFilters = remember {
         FeatureFilter
-            .availableEntries(features = features)
+            .availableEntries(features = featuresState.value)
             .map { it to false }
             .toMutableStateMap()
     }
 
-    val filteredFeatures by remember(key1 = filterQuery, key2 = selectedFilters, key3 = features) {
+    val filteredFeatures by remember {
         derivedStateOf {
+            val features = featuresState.value
             val activeTypeFilters = selectedFilters
                 .filterKeys { it == FeatureFilter.LOCAL || it == FeatureFilter.REMOTE }
                 .filterValues { it }
@@ -280,7 +281,7 @@ public fun FeatureFlipScreen(modifier: Modifier = Modifier, bottomPadding: Dp = 
             }
             itemsIndexed(
                 items = filteredFeatures,
-                key = { _, feature -> feature.hashCode() },
+                key = { _, feature -> feature.name },
                 contentType = { _, feature -> feature::class.simpleName }
             ) { index, feature ->
                 Column(

--- a/devview-featureflip/src/commonMain/kotlin/com/worldline/devview/featureflip/model/FeatureHandler.kt
+++ b/devview-featureflip/src/commonMain/kotlin/com/worldline/devview/featureflip/model/FeatureHandler.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.worldline.devview.featureflip.FeatureFlip
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import okio.IOException
 
@@ -173,7 +174,7 @@ public class FeatureHandler(
                     }
                 }
             }
-        }
+        }.distinctUntilChanged()
 
     /**
      * Checks whether a feature is currently enabled as a Compose [State].
@@ -309,7 +310,7 @@ public class FeatureHandler(
                     }
                 }
             }
-        }
+        }.distinctUntilChanged()
 
     /**
      * Provides access to all registered features as a Compose [State].

--- a/devview-featureflip/src/commonMain/kotlin/com/worldline/devview/featureflip/model/FeatureHandler.kt
+++ b/devview-featureflip/src/commonMain/kotlin/com/worldline/devview/featureflip/model/FeatureHandler.kt
@@ -322,8 +322,10 @@ public class FeatureHandler(
      *
      * @return A [State] containing the list of all features with their current state
      */
+    private val featuresFlow: Flow<List<Feature>> = getFeatures()
+
     internal val features: State<List<Feature>>
-        @Composable get() = getFeatures()
+        @Composable get() = featuresFlow
             .collectAsStateWithLifecycle(
                 initialValue = featureRegistry.keys.toList()
             )

--- a/devview-networkmock-core/src/commonMain/kotlin/com/worldline/devview/networkmock/core/repository/MockStateRepository.kt
+++ b/devview-networkmock-core/src/commonMain/kotlin/com/worldline/devview/networkmock/core/repository/MockStateRepository.kt
@@ -13,6 +13,7 @@ import com.worldline.devview.networkmock.core.model.NetworkMockState
 import kotlin.time.Clock
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.SerializationException
@@ -209,7 +210,7 @@ public class MockStateRepository(private val dataStore: DataStore<Preferences>) 
                 endpointStates = endpointStates,
                 lastModified = preferences[KEY_LAST_MODIFIED] ?: 0L
             )
-        }
+        }.distinctUntilChanged()
 
     /**
      * Gets the current network mock state as a one-time read.

--- a/devview-networkmock/src/commonMain/kotlin/com/worldline/devview/networkmock/NetworkMockScreen.kt
+++ b/devview-networkmock/src/commonMain/kotlin/com/worldline/devview/networkmock/NetworkMockScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
@@ -71,7 +71,7 @@ public fun NetworkMockScreen(
     modifier: Modifier = Modifier,
     bottomPadding: Dp = 0.dp
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(key1 = Unit) {
         resetToNetworkSharedFlow.collect {

--- a/devview/src/commonMain/kotlin/com/worldline/devview/HomeScreen.kt
+++ b/devview/src/commonMain/kotlin/com/worldline/devview/HomeScreen.kt
@@ -130,7 +130,7 @@ internal fun HomeScreen(
                 }
                 itemsIndexed(
                     items = modulesPerSection,
-                    key = { _, module -> module.hashCode() },
+                    key = { _, module -> module.moduleName },
                     contentType = { _, _ -> "Module" }
                 ) { index, module ->
                     ModuleItem(


### PR DESCRIPTION
## Summary

- **`devview-featureflip`** — fixed broken Switch animation: `LazyColumn` was using `feature.hashCode()` as item key (destroys animation state on toggle), `FeatureHandler.features` was recreating its Flow on every recomposition, and `derivedStateOf` blocks had redundant explicit `remember` keys. Added `distinctUntilChanged()` to both `isFeatureEnabledFlow` and `getFeatures`.
- **`devview-analytics`** — replaced `log.hashCode()` with `log.timestamp` as `LazyColumn` item key; removed redundant explicit keys from all four `derivedStateOf` blocks.
- **`devview`** — replaced `module.hashCode()` with `module.moduleName` as `HomeScreen` `LazyColumn` item key.
- **`devview-networkmock`** — replaced `collectAsState()` with `collectAsStateWithLifecycle()` in `NetworkMockScreen`.
- **`devview-networkmock-core`** — added `distinctUntilChanged()` to `MockStateRepository.observeState()` to suppress no-op recompositions from DataStore.

## Test plan

- [ ] Build passes: `./gradlew assembleDebug -Pandroidx.baselineprofile.skipgeneration`
- [ ] Unit tests pass: `./gradlew testAndroidHostTest -Pandroidx.baselineprofile.skipgeneration`
- [ ] Architecture tests pass: `./gradlew :konsist:test`
- [ ] Lint passes: `./gradlew detektFull`
- [ ] Manual: toggle features in `FeatureFlipScreen` — Switch animates smoothly between states
- [ ] Manual: verify Layout Inspector shows reduced recomposition counts after toggling

🤖 Generated with [Claude Code](https://claude.com/claude-code)