### PR TITLE
fix: Remove dead preview stubs in NetworkMockEndpointScreen

### DIFF
--- a/devview-networkmock/src/commonMain/kotlin/com/worldline/devview/networkmock/NetworkMockEndpointScreen.kt
+++ b/devview-networkmock/src/commonMain/kotlin/com/worldline/devview/networkmock/NetworkMockEndpointScreen.kt
@@ -94,13 +94,9 @@ internal fun NetworkMockEndpointScreen(
         )
 
         is NetworkMockEndpointUiState.Content -> {
-            // Stub for Step 3 — will be replaced with the preview sheet
-            var previewingResponse by remember { mutableStateOf<MockResponse?>(value = null) }
-
             NetworkMockEndpointScreenContent(
                 content = state,
                 onSelectResponse = viewModel::setMockState,
-                onPreviewClick = { previewingResponse = it },
                 modifier = modifier,
                 bottomPadding = bottomPadding
             )
@@ -112,7 +108,6 @@ internal fun NetworkMockEndpointScreen(
 private fun NetworkMockEndpointScreenContent(
     content: NetworkMockEndpointUiState.Content,
     onSelectResponse: (response: MockResponse?) -> Unit,
-    onPreviewClick: (MockResponse) -> Unit,
     modifier: Modifier = Modifier,
     bottomPadding: Dp = 0.dp
 ) {
@@ -315,8 +310,7 @@ private fun NetworkMockEndpointScreenPreview(
                     operationUiModel = endpointUiModel,
                     responses = MockResponse.fake(amount = 13).toPersistentList()
                 ),
-                onSelectResponse = {},
-                onPreviewClick = {}
+                onSelectResponse = {}
             )
         }
     }


### PR DESCRIPTION
## Summary

Remove dead preview stubs in NetworkMockEndpointScreen

## Changes

- Delete unused previewingResponse state leftover from Step 3 stub
- Remove unused onPreviewClick parameter and call sites
- Preview bottom sheet via previewSheetState is unchanged

Fixes #92
