### PR TITLE
feat: add console logger module

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 graphify-out/graph.json merge=graphify
+graphify-out/** linguist-generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   body on app start. Response variants are now only loaded when an operation's detail screen
   actually opens (`NetworkMockEndpointUiState.Content.responses`). (`devview-networkmock-core`,
   `devview-networkmock`)
+- `devview-consolelogger` module: displays the app's native console output (logcat on
+  Android, a stdout/stderr redirect on iOS) inside the DevView overlay, with per-level
+  filter chips, a text filter, and auto-follow. Capture works on an untethered device
+  (no debugger required) on both platforms; an optional `DevViewLogWriter` routes
+  Kermit-based logging into the same view, closing the one remaining gap
+  (`NSLog`/`os_log` on iOS with no debugger attached). Log-level colors are configurable
+  via a `LocalLogColorScheme` CompositionLocal. (`devview-consolelogger`)
 
 ## [0.1.5] - 2026-09-08
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ dependencies {
 
     implementation("com.worldline.devview:devview-featureflip:<version>")   // feature flags
     implementation("com.worldline.devview:devview-analytics:<version>")     // analytics inspector
+    implementation("com.worldline.devview:devview-consolelogger:<version>") // native console log viewer
     implementation("com.worldline.devview:devview-timecapsule:<version>")   // per-screen state history
     implementation("com.worldline.devview:devview-networkmock:<version>")   // network mock UI
 
@@ -150,6 +151,24 @@ fun CounterScreen(viewModel: CounterViewModel) {
 
 The recorded history resets automatically when the screen leaves composition.
 
+### 6. Console Logger
+
+Displays native console output (logcat on Android, a stdout/stderr redirect on iOS) inside
+DevView — works on an untethered device, no debugger required:
+
+```kotlin
+val modules = rememberModules {
+    module(module = Console())
+}
+
+// Optional: route Kermit-based logging into the same view.
+Logger.addLogWriter(DevViewLogWriter)
+```
+
+See the [Console Logger guide](https://worldline.github.io/devview/modules/consolelogger/)
+for the exact per-platform capture matrix and its one limitation (`NSLog`/`os_log` on iOS
+with no debugger attached).
+
 ---
 
 ## Available Modules
@@ -159,6 +178,7 @@ The recorded history resets automatically when the screen leaves composition.
 | Core | `devview` | `DevView` composable + `rememberModules` DSL. Required by all modules. |
 | FeatureFlip | `devview-featureflip` | Runtime feature flag management with Compose UI. Supports local and remote-config flags with local overrides. |
 | Analytics | `devview-analytics` | Real-time analytics event inspector with filtering by type, category, and time range. |
+| Console Logger | `devview-consolelogger` | Native console log viewer (logcat/stdout), untethered, with level filters and text search. |
 | TimeCapsule | `devview-timecapsule` | Records the state history of the currently visible screen and lets you restore any earlier state back into it. |
 | NetworkMock (UI) | `devview-networkmock` | Full mock management UI: enable/disable endpoints, switch responses, preview and diff mock payloads. |
 | NetworkMock Core | `devview-networkmock-core` | Mock engine: OpenAPI 3.x spec parsing, request matching, DataStore state. No UI dependency. |

--- a/config/quality/detekt/compose-config.yml
+++ b/config/quality/detekt/compose-config.yml
@@ -12,7 +12,7 @@ Compose:
   CompositionLocalAllowlist:
     active: true
     # -- You can optionally define a list of CompositionLocals that are allowed here
-    allowedCompositionLocals: LocalLoading, LocalSharedTransitionScope, LocalAnimatedVisibilityScope, LocalWindowSizeClass, LocalFeatureHandler, LocalAnalytics
+    allowedCompositionLocals: LocalLoading, LocalSharedTransitionScope, LocalAnimatedVisibilityScope, LocalWindowSizeClass, LocalFeatureHandler, LocalAnalytics, LocalConsoleLogs, LocalLogColorScheme
   CompositionLocalNaming:
     active: true
   ContentEmitterReturningValues:

--- a/devview-consolelogger/CLAUDE.md
+++ b/devview-consolelogger/CLAUDE.md
@@ -1,0 +1,186 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Module Does
+
+`devview-consolelogger` is the console-log-viewer module for the DevView developer menu. It
+tails the platform's native console output — `logcat` on Android, a `stdout`/`stderr`
+redirect on iOS — and shows it in a filterable, auto-following Compose UI, similar to
+viewing Logcat in Android Studio.
+
+The module is built around one hard requirement: capture must work on an **untethered**
+device (no debugger attached), because testers install a release build and never plug into
+a computer. See the capture matrix in `docs/modules/consolelogger.md` for exactly what each
+platform can and cannot see without a debugger — the one real gap is `NSLog`/`os_log`/Swift
+`Logger` on iOS, mitigated by `DevViewLogWriter`.
+
+## Public API Surface
+
+### `Console` — the `Module` entry point
+
+```kotlin
+Console(
+    maxEntries: Int = ConsoleLogger.DEFAULT_MAX_ENTRIES,
+    captureNativeConsole: Boolean = true
+)
+```
+
+Registered in the host app's `buildModules { }` block. `captureNativeConsole = false`
+disables the native tail entirely — only entries logged manually via `ConsoleLogger.log()`
+or `DevViewLogWriter` will appear.
+
+### `ConsoleLogger` — singleton sink
+
+| Member | Visibility | Purpose |
+|---|---|---|
+| `log(log: ConsoleLog)` | `public` | Append an entry; safe from any thread |
+| `logs: SnapshotStateList<ConsoleLog>` | `public` | Observable, bounded (ring) list |
+| `hasLogs: Boolean` | `public` | Convenience check |
+| `configure(maxEntries: Int)` | `internal` | Called once by `Console.initModule()` |
+| `collectInto()` | `internal` | The channel-drain collector; called once by `Console.initModule()` |
+| `clear()` | `internal` | Called by the in-UI "Clear" action only |
+
+### `ConsoleLog` — entry record
+
+```kotlin
+data class ConsoleLog(
+    val level: LogLevel,
+    val tag: String,       // empty when the source has no concept of a tag (iOS stdout)
+    val message: String,
+    val timestamp: Long
+)
+```
+
+### `DevViewLogWriter` — optional Kermit bridge
+
+`public object DevViewLogWriter : LogWriter()`. Forwards Kermit `Logger` calls into
+`ConsoleLogger`. Register once: `Logger.addLogWriter(DevViewLogWriter)`.
+
+### `LocalConsoleLogs` / `LocalLogColorScheme` — CompositionLocals
+
+`LocalConsoleLogs: ProvidableCompositionLocal<List<ConsoleLog>>` works exactly like
+`devview-analytics`'s `LocalAnalytics`. `LocalLogColorScheme:
+ProvidableCompositionLocal<LogColorScheme?>` is nullable — see Theming below.
+
+### `ConsoleScreen` — main composable
+
+```kotlin
+@Composable
+fun ConsoleScreen(modifier: Modifier = Modifier, bottomPadding: Dp = 0.dp)
+```
+
+Reads from `LocalConsoleLogs.current`. All filtering state (level chips, text query) and
+auto-follow state live as local `remember` state inside this composable.
+
+## Internal Architecture
+
+```
+Native capture (androidMain / iosMain)          Manual calls
+        │                                             │
+        ▼                                             ▼
+                    ConsoleLogger.log()
+                    (Channel, capacity = maxEntries, DROP_OLDEST)
+                              │
+                              ▼
+                    ConsoleLogger.collectInto()
+                    (single collector, started by Console.initModule())
+                              │
+                              ▼
+                    consoleLogs: SnapshotStateList<ConsoleLog>
+                    (bounded ring, evicts from head past maxEntries)
+                              │  provides via LocalConsoleLogs
+                              ▼
+                    ConsoleScreen (stateful Compose UI)
+                        ├── bottom bar: LogLevel FilterChips + text filter field
+                        └── LazyColumn, auto-follow unless manually scrolled
+```
+
+`log()` writes into a channel rather than appending directly to the snapshot list — unlike
+`AnalyticsLogger`, which appends hand-placed events synchronously. Native capture can emit
+far faster than the UI can usefully render, so the channel (a) makes `log()` safe to call
+from the background capture threads and (b) lets `collectInto()`'s tight drain loop absorb
+a burst in one uninterrupted pass; Compose coalesces the resulting snapshot writes into a
+single recomposition rather than one per line.
+
+`Console.initModule()` calls `ConsoleLogger.configure(maxEntries)` then launches two
+coroutines: the `collectInto()` drain, and — if `captureNativeConsole` — the platform
+capture. The capture coroutine is wrapped in its own `try`/`catch` (rethrowing
+`CancellationException`) so a capture failure (e.g. an OEM ROM blocking `logcat`) can't
+cancel the sibling drain job and silently break manual logging too.
+
+## Platform-Specific Code
+
+This is the first DevView feature module with real `androidMain`/`iosMain` source sets and
+`expect`/`actual` declarations (`devview-analytics` and `devview-timecapsule` have none).
+
+**`ConsoleCapture.kt`** (`commonMain`) declares `internal expect suspend fun
+tailNativeConsole()`. Runs until the calling coroutine is cancelled.
+
+**`ConsoleCapture.android.kt`**: spawns `logcat -v brief --pid=<self>` via `ProcessBuilder`,
+parses each line with `parseLogcatLine` (`LogcatLine.kt`, `commonMain` — pure string logic,
+tested directly in `commonTest` rather than needing an Android-only test source set). If
+`ProcessBuilder.start()` throws `IOException` (some OEM ROMs block `logcat` for third-party
+apps), it logs a warning via Kermit and returns — native capture is disabled for that
+session, but `ConsoleLogger.log()`/`DevViewLogWriter` keep working.
+
+**`ConsoleCapture.ios.kt`**: redirects `stdout` and `stderr` through separate in-process
+`platform.posix` pipes (`dup`/`pipe`/`dup2`), so it works without a debugger attached —
+this is what makes iOS capture untethered-safe. Key details, in case this needs revisiting:
+- The write end (the fd `dup2`'d over `STDOUT_FILENO`/`STDERR_FILENO`) is set `O_NONBLOCK`.
+  Without it, a stalled reader fills the pipe buffer and every subsequent `println` in the
+  host app blocks forever; with it, writes past capacity drop instead — the correct
+  trade-off for a dev tool.
+- `stdout` is switched to `_IOLBF` (line-buffered) via `setvbuf`, since a pipe isn't a tty
+  and libc would otherwise default to 4KB full buffering, arriving in bursts.
+- Bytes read from the pipe are written back to the *original* fd (`saved`, from `dup()`
+  before redirecting) so Xcode's console still shows everything when the device is
+  tethered — the redirect is additive, not a replacement.
+- Cannot see `NSLog`/`os_log`/Swift `Logger` — those bypass the file descriptor. This is
+  the gap `DevViewLogWriter` exists to mitigate.
+
+No cinterop `.def` files or Swift shims are needed for any of this — everything used is
+already exposed by Kotlin/Native's bundled `platform.posix` and `kotlinx.cinterop`.
+
+## Theming
+
+`LogColorScheme` (`theme/LogColorScheme.kt`) holds two complete, hand-tuned palettes
+(`Light`/`Dark`) covering all seven `LogLevel` entries — ported verbatim from a prior
+Android-only implementation, deliberately *not* derived from `MaterialTheme.colorScheme`,
+since log-level colors need to stay visually distinct and theme-independent.
+
+Integrators provide the palette via `LocalLogColorScheme` at their app's theme site (see
+`docs/guides/theming.md`), not via a `Console` constructor parameter — `rememberModules { }`
+(where `Console` is constructed) typically runs before the host's dark/light state is
+readable, and a constructor param would be captured once rather than staying reactive to a
+runtime theme toggle. `theme/LocalLogColorScheme.kt`'s internal `rememberLogColorScheme()`
+resolves the CompositionLocal, or falls back to a luminance-based guess with a one-time
+Kermit warning if it was never provided.
+
+## Non-Obvious Patterns
+
+- **`ConsoleLogger.DEFAULT_MAX_ENTRIES`** is also the channel capacity used before
+  `configure()` runs — so `log()`/`DevViewLogWriter` calls made very early (before
+  `Console.initModule()` composes) aren't lost, just buffered against the default.
+- **Bounded ring, not unbounded list.** The prior Android-only implementation used an
+  unbounded `mutableStateListOf`, which could OOM on a sustained logcat firehose. Both the
+  channel (capacity `maxEntries`, `DROP_OLDEST`) and the retained `consoleLogs` list
+  (evicts from the head) are bounded to the same figure.
+- **`DevViewLogWriter` + Android `LogcatWriter` double-logs.** If a host app registers both
+  `DevViewLogWriter` and Kermit's own `LogcatWriter` on Android, every Kermit call appears
+  twice in the Console screen — once via the writer, once via the logcat tail picking up
+  what `LogcatWriter` already wrote to logcat. Documented as a known trade-off, not a bug.
+
+## Testing
+
+`commonTest` covers `ConsoleLogger` (ring eviction, `clear()`), `LogcatLine` (every priority
+prefix, the `UNKNOWN` fallback for unparseable lines), `DevViewLogWriter` (`Severity`
+mapping, throwable formatting), `Console` (module metadata/actions), and `LogColorScheme`
+(`get(level)`, `copy()`). `androidDeviceTest` covers `ConsoleScreen` (empty state, text
+filter, level-chip filter) and `rememberLogColorScheme()`'s resolution logic.
+
+The `ConsoleCapture.ios.kt` actual has no automated test — it can only be exercised on a
+Mac. CI verifies it compiles via the `ios-build` job (`compileKotlinIosArm64
+iosSimulatorArm64Test`) on `macos-26`; manual verification requires running the sample on
+an iOS simulator or device and confirming `println` output reaches the Console screen while
+still appearing in the Xcode console (the tee-back).

--- a/devview-consolelogger/api/api.txt
+++ b/devview-consolelogger/api/api.txt
@@ -1,0 +1,143 @@
+// Signature format: 4.0
+package com.worldline.devview.consolelogger {
+
+  public final class Console implements com.worldline.devview.core.Module {
+    ctor public Console();
+    ctor public Console(optional int maxEntries, optional boolean captureNativeConsole);
+    method @InaccessibleFromKotlin public boolean getCaptureNativeConsole();
+    method @InaccessibleFromKotlin public kotlinx.collections.immutable.PersistentMap<kotlin.reflect.KClass<? extends androidx.navigation3.runtime.NavKey>,com.worldline.devview.core.DestinationMetadata> getDestinations();
+    method @InaccessibleFromKotlin public androidx.navigation3.runtime.NavKey getEntryDestination();
+    method @InaccessibleFromKotlin public int getMaxEntries();
+    method @InaccessibleFromKotlin public kotlin.jvm.functions.Function1<kotlinx.serialization.modules.PolymorphicModuleBuilder<? super androidx.navigation3.runtime.NavKey>,kotlin.Unit> getRegisterSerializers();
+    method @InaccessibleFromKotlin public com.worldline.devview.core.Section getSection();
+    method @KotlinOnly @androidx.compose.runtime.Composable public void initModule();
+    method @KotlinOnly public void registerContent(androidx.navigation3.runtime.EntryProviderScope<androidx.navigation3.runtime.NavKey>, kotlin.jvm.functions.Function0<kotlin.Unit> onNavigateBack, kotlin.jvm.functions.Function1<androidx.navigation3.runtime.NavKey,kotlin.Unit> onNavigate, androidx.compose.ui.unit.Dp bottomPadding);
+    property public boolean captureNativeConsole;
+    property public kotlinx.collections.immutable.PersistentMap<kotlin.reflect.KClass<? extends androidx.navigation3.runtime.NavKey>,com.worldline.devview.core.DestinationMetadata> destinations;
+    property public androidx.navigation3.runtime.NavKey entryDestination;
+    property public androidx.compose.ui.graphics.vector.ImageVector icon;
+    property public int maxEntries;
+    property public kotlin.jvm.functions.Function1<kotlinx.serialization.modules.PolymorphicModuleBuilder<androidx.navigation3.runtime.NavKey>,kotlin.Unit> registerSerializers;
+    property public com.worldline.devview.core.Section section;
+  }
+
+  public sealed exhaustive interface ConsoleDestination extends androidx.navigation3.runtime.NavKey {
+  }
+
+  @kotlinx.serialization.Serializable public static final class ConsoleDestination.Main implements com.worldline.devview.consolelogger.ConsoleDestination {
+    field public static final com.worldline.devview.consolelogger.ConsoleDestination.Main INSTANCE;
+  }
+
+  public final class ConsoleLogger {
+    method @InaccessibleFromKotlin public boolean getHasLogs();
+    method @InaccessibleFromKotlin public androidx.compose.runtime.snapshots.SnapshotStateList<com.worldline.devview.consolelogger.model.ConsoleLog> getLogs();
+    method public void log(com.worldline.devview.consolelogger.model.ConsoleLog log);
+    property public boolean hasLogs;
+    property public androidx.compose.runtime.snapshots.SnapshotStateList<com.worldline.devview.consolelogger.model.ConsoleLog> logs;
+    field public static final com.worldline.devview.consolelogger.ConsoleLogger INSTANCE;
+  }
+
+  public final class ConsoleLoggerKt {
+    method @InaccessibleFromKotlin public static androidx.compose.runtime.ProvidableCompositionLocal<java.util.List<com.worldline.devview.consolelogger.model.ConsoleLog>> getLocalConsoleLogs();
+    property public static androidx.compose.runtime.ProvidableCompositionLocal<java.util.List<com.worldline.devview.consolelogger.model.ConsoleLog>> LocalConsoleLogs;
+  }
+
+  public final class ConsoleScreenKt {
+    method @KotlinOnly @androidx.compose.runtime.Composable public static void ConsoleScreen(optional androidx.compose.ui.Modifier modifier, optional androidx.compose.ui.unit.Dp bottomPadding);
+  }
+
+  public final class DevViewLogWriter extends co.touchlab.kermit.LogWriter {
+    method public void log(co.touchlab.kermit.Severity severity, String message, String tag, Throwable? throwable);
+    field public static final com.worldline.devview.consolelogger.DevViewLogWriter INSTANCE;
+  }
+
+}
+
+package com.worldline.devview.consolelogger.model {
+
+  @androidx.compose.runtime.Immutable public final class ConsoleLog {
+    ctor public ConsoleLog(com.worldline.devview.consolelogger.model.LogLevel level, String tag, String message, long timestamp);
+    method public com.worldline.devview.consolelogger.model.LogLevel component1();
+    method public String component2();
+    method public String component3();
+    method public long component4();
+    method public com.worldline.devview.consolelogger.model.ConsoleLog copy(optional com.worldline.devview.consolelogger.model.LogLevel level, optional String tag, optional String message, optional long timestamp);
+    method @InaccessibleFromKotlin public com.worldline.devview.consolelogger.model.LogLevel getLevel();
+    method @InaccessibleFromKotlin public String getMessage();
+    method @InaccessibleFromKotlin public String getTag();
+    method @InaccessibleFromKotlin public long getTimestamp();
+    property public com.worldline.devview.consolelogger.model.LogLevel level;
+    property public String message;
+    property public String tag;
+    property public long timestamp;
+  }
+
+  @androidx.compose.runtime.Stable public enum LogLevel {
+    enum_constant public static final com.worldline.devview.consolelogger.model.LogLevel ASSERT;
+    enum_constant public static final com.worldline.devview.consolelogger.model.LogLevel DEBUG;
+    enum_constant public static final com.worldline.devview.consolelogger.model.LogLevel ERROR;
+    enum_constant public static final com.worldline.devview.consolelogger.model.LogLevel INFO;
+    enum_constant public static final com.worldline.devview.consolelogger.model.LogLevel UNKNOWN;
+    enum_constant public static final com.worldline.devview.consolelogger.model.LogLevel VERBOSE;
+    enum_constant public static final com.worldline.devview.consolelogger.model.LogLevel WARNING;
+  }
+
+}
+
+package com.worldline.devview.consolelogger.theme {
+
+  public final class LocalLogColorSchemeKt {
+    method @InaccessibleFromKotlin public static androidx.compose.runtime.ProvidableCompositionLocal<com.worldline.devview.consolelogger.theme.LogColorScheme?> getLocalLogColorScheme();
+    property public static androidx.compose.runtime.ProvidableCompositionLocal<com.worldline.devview.consolelogger.theme.LogColorScheme?> LocalLogColorScheme;
+  }
+
+  @androidx.compose.runtime.Immutable public final class LogColorScheme {
+    ctor public LogColorScheme(com.worldline.devview.consolelogger.theme.LogLevelColors verbose, com.worldline.devview.consolelogger.theme.LogLevelColors debug, com.worldline.devview.consolelogger.theme.LogLevelColors info, com.worldline.devview.consolelogger.theme.LogLevelColors warning, com.worldline.devview.consolelogger.theme.LogLevelColors error, com.worldline.devview.consolelogger.theme.LogLevelColors assert, com.worldline.devview.consolelogger.theme.LogLevelColors unknown);
+    method public com.worldline.devview.consolelogger.theme.LogLevelColors component1();
+    method public com.worldline.devview.consolelogger.theme.LogLevelColors component2();
+    method public com.worldline.devview.consolelogger.theme.LogLevelColors component3();
+    method public com.worldline.devview.consolelogger.theme.LogLevelColors component4();
+    method public com.worldline.devview.consolelogger.theme.LogLevelColors component5();
+    method public com.worldline.devview.consolelogger.theme.LogLevelColors component6();
+    method public com.worldline.devview.consolelogger.theme.LogLevelColors component7();
+    method public com.worldline.devview.consolelogger.theme.LogColorScheme copy(optional com.worldline.devview.consolelogger.theme.LogLevelColors verbose, optional com.worldline.devview.consolelogger.theme.LogLevelColors debug, optional com.worldline.devview.consolelogger.theme.LogLevelColors info, optional com.worldline.devview.consolelogger.theme.LogLevelColors warning, optional com.worldline.devview.consolelogger.theme.LogLevelColors error, optional com.worldline.devview.consolelogger.theme.LogLevelColors assert, optional com.worldline.devview.consolelogger.theme.LogLevelColors unknown);
+    method public operator com.worldline.devview.consolelogger.theme.LogLevelColors get(com.worldline.devview.consolelogger.model.LogLevel level);
+    method @InaccessibleFromKotlin public com.worldline.devview.consolelogger.theme.LogLevelColors getAssert();
+    method @InaccessibleFromKotlin public com.worldline.devview.consolelogger.theme.LogLevelColors getDebug();
+    method @InaccessibleFromKotlin public com.worldline.devview.consolelogger.theme.LogLevelColors getError();
+    method @InaccessibleFromKotlin public com.worldline.devview.consolelogger.theme.LogLevelColors getInfo();
+    method @InaccessibleFromKotlin public com.worldline.devview.consolelogger.theme.LogLevelColors getUnknown();
+    method @InaccessibleFromKotlin public com.worldline.devview.consolelogger.theme.LogLevelColors getVerbose();
+    method @InaccessibleFromKotlin public com.worldline.devview.consolelogger.theme.LogLevelColors getWarning();
+    property public com.worldline.devview.consolelogger.theme.LogLevelColors assert;
+    property public com.worldline.devview.consolelogger.theme.LogLevelColors debug;
+    property public com.worldline.devview.consolelogger.theme.LogLevelColors error;
+    property public com.worldline.devview.consolelogger.theme.LogLevelColors info;
+    property public com.worldline.devview.consolelogger.theme.LogLevelColors unknown;
+    property public com.worldline.devview.consolelogger.theme.LogLevelColors verbose;
+    property public com.worldline.devview.consolelogger.theme.LogLevelColors warning;
+    field public static final com.worldline.devview.consolelogger.theme.LogColorScheme.Companion Companion;
+  }
+
+  public static final class LogColorScheme.Companion {
+    method @InaccessibleFromKotlin public com.worldline.devview.consolelogger.theme.LogColorScheme getDark();
+    method @InaccessibleFromKotlin public com.worldline.devview.consolelogger.theme.LogColorScheme getLight();
+    property public com.worldline.devview.consolelogger.theme.LogColorScheme Dark;
+    property public com.worldline.devview.consolelogger.theme.LogColorScheme Light;
+  }
+
+  @androidx.compose.runtime.Immutable public final class LogLevelColors {
+    ctor @KotlinOnly public LogLevelColors(androidx.compose.ui.graphics.Color label, androidx.compose.ui.graphics.Color selectedContainer, androidx.compose.ui.graphics.Color selectedContent, androidx.compose.ui.graphics.Color unselectedContent);
+    method @KotlinOnly public operator androidx.compose.ui.graphics.Color component1();
+    method @KotlinOnly public operator androidx.compose.ui.graphics.Color component2();
+    method @KotlinOnly public operator androidx.compose.ui.graphics.Color component3();
+    method @KotlinOnly public operator androidx.compose.ui.graphics.Color component4();
+    method @KotlinOnly public com.worldline.devview.consolelogger.theme.LogLevelColors copy(optional androidx.compose.ui.graphics.Color label, optional androidx.compose.ui.graphics.Color selectedContainer, optional androidx.compose.ui.graphics.Color selectedContent, optional androidx.compose.ui.graphics.Color unselectedContent);
+    property public androidx.compose.ui.graphics.Color label;
+    property public androidx.compose.ui.graphics.Color selectedContainer;
+    property public androidx.compose.ui.graphics.Color selectedContent;
+    property public androidx.compose.ui.graphics.Color unselectedContent;
+  }
+
+}
+

--- a/devview-consolelogger/build.gradle.kts
+++ b/devview-consolelogger/build.gradle.kts
@@ -1,0 +1,42 @@
+plugins {
+    alias(libs.plugins.convention.multiplatform.library)
+    alias(libs.plugins.convention.compose.multiplatform)
+    alias(libs.plugins.convention.unitTest)
+    alias(libs.plugins.convention.deviceTest)
+    alias(libs.plugins.convention.kover)
+    alias(libs.plugins.convention.metalava)
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.maven.publish)
+}
+
+kotlin {
+    addDefaultDevViewTargets()
+
+    android {
+        namespace = "com.worldline.devview.consolelogger"
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(projects.devview)
+                // Non-implementation: DevViewLogWriter extends Kermit's LogWriter,
+                // so LogWriter must be visible to consumers of the public API.
+                api(libs.kermit)
+                implementation(libs.kotlinx.coroutines.core)
+                implementation(libs.kotlinx.collections.immutable)
+                implementation(libs.kotlinx.datetime)
+            }
+        }
+
+        androidDeviceTest {
+            dependencies {
+                implementation(projects.devviewTest)
+            }
+        }
+    }
+}
+
+tasks.withType<Test> {
+    failOnNoDiscoveredTests.set(false)
+}

--- a/devview-consolelogger/gradle.properties
+++ b/devview-consolelogger/gradle.properties
@@ -1,0 +1,2 @@
+POM_ARTIFACT_ID=devview-consolelogger
+POM_NAME=DevView Console Logger

--- a/devview-consolelogger/src/androidDeviceTest/kotlin/com/worldline/devview/consolelogger/ConsoleScreenTest.kt
+++ b/devview-consolelogger/src/androidDeviceTest/kotlin/com/worldline/devview/consolelogger/ConsoleScreenTest.kt
@@ -1,0 +1,124 @@
+package com.worldline.devview.consolelogger
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.v2.runComposeUiTest
+import com.worldline.devview.consolelogger.model.ConsoleLog
+import com.worldline.devview.consolelogger.model.LogLevel
+import com.worldline.devview.consolelogger.theme.LocalLogColorScheme
+import com.worldline.devview.consolelogger.theme.LogColorScheme
+import com.worldline.devview.consolelogger.theme.rememberLogColorScheme
+import com.worldline.devview.test.waitUntilTagCount
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+
+class ConsoleScreenTest {
+
+    @Test
+    fun consoleScreen_shows_empty_state_when_no_logs() = runComposeUiTest {
+        setContent {
+            CompositionLocalProvider(
+                LocalConsoleLogs provides emptyList(),
+                LocalLogColorScheme provides LogColorScheme.Light
+            ) {
+                ConsoleScreen()
+            }
+        }
+
+        waitUntilTagCount(tag = "console_empty_state", expectedCount = 1)
+    }
+
+    @Test
+    fun consoleScreen_filters_by_query_and_clear_restores_results() = runComposeUiTest {
+        val logs = listOf(
+            log(tag = "network", message = "request sent"),
+            log(tag = "ui", message = "button clicked")
+        )
+
+        setContent {
+            CompositionLocalProvider(
+                LocalConsoleLogs provides logs,
+                LocalLogColorScheme provides LogColorScheme.Light
+            ) {
+                ConsoleScreen()
+            }
+        }
+
+        waitUntilTagCount(tag = "console_log_item_0", expectedCount = 1)
+        waitUntilTagCount(tag = "console_log_item_1", expectedCount = 1)
+
+        onNodeWithTag(testTag = "console_filter_field").performTextInput("network")
+
+        waitUntilTagCount(tag = "console_log_item_0", expectedCount = 1)
+        waitUntilTagCount(tag = "console_log_item_1", expectedCount = 0)
+
+        onNodeWithTag(testTag = "clear_filter_button").performClick()
+
+        waitUntilTagCount(tag = "console_log_item_1", expectedCount = 1)
+    }
+
+    @Test
+    fun consoleScreen_can_filter_by_level_chip() = runComposeUiTest {
+        val logs = listOf(
+            log(tag = "a", message = "info line", level = LogLevel.INFO),
+            log(tag = "b", message = "error line", level = LogLevel.ERROR)
+        )
+
+        setContent {
+            CompositionLocalProvider(
+                LocalConsoleLogs provides logs,
+                LocalLogColorScheme provides LogColorScheme.Light
+            ) {
+                ConsoleScreen()
+            }
+        }
+
+        onNodeWithTag(testTag = "console_level_chip_ERROR").performClick()
+
+        waitUntilTagCount(tag = "console_log_item_0", expectedCount = 1)
+        waitUntilTagCount(tag = "console_log_item_1", expectedCount = 0)
+    }
+
+    @Test
+    fun rememberLogColorScheme_honours_explicit_LocalLogColorScheme() = runComposeUiTest {
+        var resolved: LogColorScheme? = null
+
+        setContent {
+            MaterialTheme(colorScheme = darkColorScheme()) {
+                CompositionLocalProvider(LocalLogColorScheme provides LogColorScheme.Light) {
+                    resolved = rememberLogColorScheme()
+                }
+            }
+        }
+        waitForIdle()
+
+        resolved shouldBe LogColorScheme.Light
+    }
+
+    @Test
+    fun rememberLogColorScheme_falls_back_to_dark_when_none_provided_and_theme_is_dark() = runComposeUiTest {
+        var resolved: LogColorScheme? = null
+
+        setContent {
+            MaterialTheme(colorScheme = darkColorScheme()) {
+                resolved = rememberLogColorScheme()
+            }
+        }
+        waitForIdle()
+
+        resolved shouldBe LogColorScheme.Dark
+    }
+
+    private var logIdCounter = 0L
+
+    private fun log(
+        tag: String,
+        message: String,
+        level: LogLevel = LogLevel.INFO,
+        timestamp: Long = logIdCounter++
+    ): ConsoleLog = ConsoleLog(level = level, tag = tag, message = message, timestamp = timestamp)
+}

--- a/devview-consolelogger/src/androidMain/kotlin/com/worldline/devview/consolelogger/ConsoleCapture.android.kt
+++ b/devview-consolelogger/src/androidMain/kotlin/com/worldline/devview/consolelogger/ConsoleCapture.android.kt
@@ -1,0 +1,43 @@
+package com.worldline.devview.consolelogger
+
+import co.touchlab.kermit.Logger
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+
+/**
+ * Tails `logcat` scoped to this process's PID.
+ *
+ * Reading your own app's logcat needs no permission and works on an untethered, released
+ * build. Some OEM ROMs block `logcat` for third-party apps entirely — in that case the
+ * process fails to start or its output stream ends immediately, and this function simply
+ * returns without native capture; [ConsoleLogger.log] and [DevViewLogWriter] still work.
+ */
+@Suppress("InjectDispatcher") // platform actual: no DI framework to inject a test dispatcher into
+internal actual suspend fun tailNativeConsole(): Unit = withContext(context = Dispatchers.IO) {
+    val process = try {
+        ProcessBuilder("logcat", "-v", "brief", "--pid=${android.os.Process.myPid()}")
+            .redirectErrorStream(true)
+            .start()
+    } catch (exception: IOException) {
+        Logger.w(throwable = exception, tag = "DevViewConsole") {
+            "logcat process failed to start; native console capture disabled for this session"
+        }
+        return@withContext
+    }
+
+    try {
+        process.inputStream.bufferedReader().useLines { lines ->
+            lines.forEach { line ->
+                currentCoroutineContext().ensureActive()
+                ConsoleLogger.log(log = parseLogcatLine(line = line))
+            }
+        }
+    } finally {
+        // ponytail: the blocking readLine() above only observes cancellation once a line
+        // arrives or the process exits; destroy() unblocks it immediately on cancellation.
+        process.destroy()
+    }
+}

--- a/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/Console.kt
+++ b/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/Console.kt
@@ -1,0 +1,150 @@
+package com.worldline.devview.consolelogger
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Terminal
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Dp
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import co.touchlab.kermit.Logger
+import com.worldline.devview.core.DestinationMetadata
+import com.worldline.devview.core.Module
+import com.worldline.devview.core.ModuleDestinationActionPopup
+import com.worldline.devview.core.Section
+import com.worldline.devview.core.withTitle
+import kotlin.reflect.KClass
+import kotlinx.collections.immutable.PersistentMap
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.PolymorphicModuleBuilder
+
+/**
+ * Navigation destinations for the Console module.
+ *
+ * @see Console
+ */
+public sealed interface ConsoleDestination : NavKey {
+    /**
+     * Main console log screen destination.
+     *
+     * @see ConsoleScreen
+     */
+    @Serializable
+    public data object Main : ConsoleDestination
+}
+
+/**
+ * Console Logger module for the DevView developer tools suite.
+ *
+ * Captures the platform's native console output — `logcat` on Android, a `stdout`/`stderr`
+ * redirect on iOS — and displays it in a filterable, auto-following list, similar to
+ * viewing Logcat in Android Studio.
+ *
+ * ## Features
+ * - Native console capture that works on an untethered device (see the module docs for the
+ *   exact capture matrix per platform)
+ * - Bounded, drop-oldest history (default 1000 entries) so a logcat firehose can't OOM the
+ *   host app
+ * - Per-[com.worldline.devview.consolelogger.model.LogLevel] filter chips and a text filter
+ * - Optional [DevViewLogWriter] for routing Kermit-based logging into the same view
+ *
+ * ## Integration
+ * ```kotlin
+ * val modules = rememberModules {
+ *     module(Console())
+ * }
+ * ```
+ *
+ * @property maxEntries Maximum number of console log entries retained in memory. Oldest
+ *           entries are evicted first.
+ * @property captureNativeConsole Whether to automatically tail the platform's native console
+ *           output. Set to `false` to only receive entries logged manually via
+ *           [ConsoleLogger.log] or [DevViewLogWriter].
+ *
+ * @see Module
+ * @see Section.LOGGING
+ * @see ConsoleLogger
+ * @see ConsoleScreen
+ */
+public class Console(
+    public val maxEntries: Int = ConsoleLogger.DEFAULT_MAX_ENTRIES,
+    public val captureNativeConsole: Boolean = true
+) : Module {
+    override val section: Section
+        get() = Section.LOGGING
+
+    override val icon: ImageVector
+        get() = Icons.Rounded.Terminal
+
+    override val destinations: PersistentMap<KClass<out NavKey>, DestinationMetadata> = persistentMapOf(
+        ConsoleDestination.Main.withTitle(title = "Console") {
+            action(
+                icon = Icons.Rounded.Delete,
+                popup = ModuleDestinationActionPopup(
+                    title = "Clear Logs",
+                    subtitle = "Remove all captured console log lines",
+                    confirmButton = "Clear",
+                    dismissButton = "Cancel"
+                )
+            ) {
+                ConsoleLogger.clear()
+            }
+        }
+    )
+
+    override val entryDestination: NavKey = ConsoleDestination.Main
+
+    override val registerSerializers: PolymorphicModuleBuilder<NavKey>.() -> Unit
+        get() = {
+            subclass(
+                subclass = ConsoleDestination.Main::class,
+                serializer = ConsoleDestination.Main.serializer()
+            )
+        }
+
+    override fun EntryProviderScope<NavKey>.registerContent(
+        onNavigateBack: () -> Unit,
+        onNavigate: (NavKey) -> Unit,
+        bottomPadding: Dp
+    ) {
+        entry<ConsoleDestination.Main> {
+            ConsoleScreen(
+                modifier = Modifier.fillMaxSize(),
+                bottomPadding = bottomPadding
+            )
+        }
+    }
+
+    @Composable
+    override fun initModule() {
+        ConsoleLogger.configure(maxEntries = maxEntries)
+
+        LaunchedEffect(key1 = Unit) {
+            launch { ConsoleLogger.collectInto() }
+            if (captureNativeConsole) {
+                launch {
+                    // Isolate native capture failures from the log-drain job above: a
+                    // crash here (e.g. an OEM ROM blocking logcat) must not take down the
+                    // whole console. Cancellation itself must still propagate normally.
+                    @Suppress("TooGenericExceptionCaught")
+                    try {
+                        tailNativeConsole()
+                    } catch (cancellation: CancellationException) {
+                        throw cancellation
+                    } catch (throwable: Throwable) {
+                        Logger.w(throwable = throwable, tag = "DevViewConsole") {
+                            "Native console capture stopped unexpectedly"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/ConsoleCapture.kt
+++ b/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/ConsoleCapture.kt
@@ -1,0 +1,14 @@
+package com.worldline.devview.consolelogger
+
+/**
+ * Captures the platform's native console output and forwards each line to
+ * [ConsoleLogger.log] until the calling coroutine is cancelled.
+ *
+ * - **Android**: tails `logcat` scoped to this process (`--pid=<self>`), so it needs no
+ *   permission and works on an untethered, released build.
+ * - **iOS**: redirects `stdout`/`stderr` through a pipe read in-process, so it also works
+ *   without a debugger attached. It cannot see `NSLog`/`os_log`/Swift `Logger` output on a
+ *   device with no debugger attached — see the module's documentation for the full capture
+ *   matrix and the [DevViewLogWriter] mitigation.
+ */
+internal expect suspend fun tailNativeConsole()

--- a/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/ConsoleLogger.kt
+++ b/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/ConsoleLogger.kt
@@ -1,0 +1,126 @@
+package com.worldline.devview.consolelogger
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.worldline.devview.consolelogger.model.ConsoleLog
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+
+/**
+ * Central sink for captured console log lines.
+ *
+ * Unlike [com.worldline.devview.analytics.AnalyticsLogger][analytics logger], which appends
+ * hand-placed events directly to its backing list, [ConsoleLogger.log] writes into a
+ * bounded, drop-oldest [Channel] instead. Native console capture (logcat on Android, a
+ * stdout/stderr redirect on iOS) runs off the main thread and can emit far faster than the
+ * UI can usefully render, so the channel both makes [log] safe to call from those capture
+ * threads and lets the single collector in [collectInto] drain everything currently buffered
+ * in one uninterrupted burst — Compose coalesces the resulting snapshot writes into a single
+ * recomposition rather than one per line.
+ *
+ * The channel's capacity — and the retained history size — is configured once via
+ * [configure], called by `Console.initModule()` before the collector starts.
+ *
+ * @see ConsoleLog
+ * @see LocalConsoleLogs
+ */
+public object ConsoleLogger {
+    /** Capacity used before [configure] has run, e.g. if [log] is called very early. */
+    internal const val DEFAULT_MAX_ENTRIES: Int = 1_000
+
+    private val consoleLogs = mutableStateListOf<ConsoleLog>()
+
+    private var maxEntries: Int = DEFAULT_MAX_ENTRIES
+    private var channel: Channel<ConsoleLog> = newChannel(capacity = DEFAULT_MAX_ENTRIES)
+
+    /**
+     * Appends a new console log line.
+     *
+     * Safe to call from any thread, including the background thread(s) driving native
+     * console capture. If the channel is full, the oldest buffered-but-not-yet-drained
+     * entry is dropped in favor of this one.
+     *
+     * @param log The console log entry to append.
+     */
+    public fun log(log: ConsoleLog) {
+        channel.trySend(element = log)
+    }
+
+    /**
+     * Clears all stored console logs.
+     *
+     * This method is intended for internal use by the DevView framework.
+     */
+    internal fun clear() {
+        consoleLogs.clear()
+    }
+
+    /**
+     * (Re)configures the retained history size and the drop-oldest channel capacity.
+     *
+     * Must be called before [collectInto] starts collecting; calling it afterwards has no
+     * effect on the already-running collector.
+     */
+    internal fun configure(maxEntries: Int) {
+        require(value = maxEntries > 0) { "maxEntries must be > 0, was $maxEntries" }
+        this.maxEntries = maxEntries
+        channel = newChannel(capacity = maxEntries)
+    }
+
+    /**
+     * Drains [log] entries as they arrive, evicting from the head once [maxEntries] is
+     * exceeded. Suspends until cancelled.
+     */
+    internal suspend fun collectInto() {
+        for (first in channel) {
+            appendBounded(log = first)
+            while (true) {
+                val next = channel.tryReceive().getOrNull() ?: break
+                appendBounded(log = next)
+            }
+        }
+    }
+
+    private fun appendBounded(log: ConsoleLog) {
+        if (consoleLogs.size >= maxEntries) {
+            consoleLogs.removeAt(index = 0)
+        }
+        consoleLogs.add(element = log)
+    }
+
+    /**
+     * Returns a snapshot state list of all retained console logs, oldest first.
+     *
+     * This property provides reactive access to the logs, meaning any Compose UI observing
+     * this property will automatically recompose when logs are added or removed.
+     */
+    public val logs: SnapshotStateList<ConsoleLog>
+        get() = consoleLogs
+
+    /**
+     * Indicates whether any console logs have been recorded.
+     */
+    public val hasLogs: Boolean
+        get() = consoleLogs.isNotEmpty()
+
+    private fun newChannel(capacity: Int): Channel<ConsoleLog> =
+        Channel(capacity = capacity, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+}
+
+/**
+ * CompositionLocal for providing console logs to Compose UI components.
+ *
+ * The DevView host wraps module content with
+ * `CompositionLocalProvider(LocalConsoleLogs provides ConsoleLogger.logs)` before rendering
+ * module destinations.
+ *
+ * @throws IllegalStateException if accessed without being provided in the Compose tree.
+ *
+ * @see ConsoleLogger
+ */
+public val LocalConsoleLogs: ProvidableCompositionLocal<List<ConsoleLog>> =
+    staticCompositionLocalOf {
+        error(message = "No console logs provided.")
+    }

--- a/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/ConsoleScreen.kt
+++ b/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/ConsoleScreen.kt
@@ -1,0 +1,302 @@
+package com.worldline.devview.consolelogger
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowDownward
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Done
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.structuralEqualityPolicy
+import androidx.compose.runtime.toMutableStateMap
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.worldline.devview.consolelogger.model.ConsoleLog
+import com.worldline.devview.consolelogger.model.LogLevel
+import com.worldline.devview.consolelogger.preview.ConsoleLogListPreviewParameterProvider
+import com.worldline.devview.consolelogger.theme.LocalLogColorScheme
+import com.worldline.devview.consolelogger.theme.LogColorScheme
+import com.worldline.devview.consolelogger.theme.rememberLogColorScheme
+
+/**
+ * Main UI component for displaying captured console logs.
+ *
+ * Renders a scrollable, auto-following list of console log lines colored by [LogLevel],
+ * with a bottom bar providing per-level filter chips and a text filter over tag/message.
+ * Scrolling up disables auto-follow; a floating action button re-enables it and jumps back
+ * to the latest entry.
+ *
+ * ## Usage
+ * ```kotlin
+ * CompositionLocalProvider(LocalConsoleLogs provides ConsoleLogger.logs) {
+ *     ConsoleScreen(modifier = Modifier.fillMaxSize())
+ * }
+ * ```
+ *
+ * @param modifier Modifier to be applied to the root [Scaffold].
+ * @param bottomPadding Additional bottom padding applied to the bottom bar content, used to
+ *        avoid overlap with system UI elements when this screen is nested inside another
+ *        [Scaffold].
+ *
+ * @see ConsoleLogger
+ * @see LocalConsoleLogs
+ * @see ConsoleLog
+ */
+@Composable
+public fun ConsoleScreen(modifier: Modifier = Modifier, bottomPadding: Dp = 0.dp) {
+    val consoleLogs = LocalConsoleLogs.current
+    val logColorScheme = rememberLogColorScheme()
+
+    val selectedFilters = remember {
+        LogLevel.entries.map { it to false }.toMutableStateMap()
+    }
+
+    var filterQuery by remember { mutableStateOf(value = "") }
+
+    val filteredConsoleLogs by remember {
+        derivedStateOf(policy = structuralEqualityPolicy()) {
+            consoleLogs.filter { log ->
+                val matchesLevel =
+                    selectedFilters.values.all { !it } || selectedFilters[log.level] == true
+                val matchesQuery = filterQuery.isBlank() ||
+                    log.tag.contains(other = filterQuery, ignoreCase = true) ||
+                    log.message.contains(other = filterQuery, ignoreCase = true)
+                matchesLevel && matchesQuery
+            }
+        }
+    }
+
+    var enableAutoScroll by remember { mutableStateOf(value = true) }
+    val lazyColumnState = rememberLazyListState()
+
+    val nestedScrollConnection = remember {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                if (available.y != 0f && enableAutoScroll) {
+                    enableAutoScroll = false
+                }
+                return Offset.Zero
+            }
+        }
+    }
+
+    LaunchedEffect(key1 = filteredConsoleLogs.size, key2 = enableAutoScroll) {
+        if (filteredConsoleLogs.isNotEmpty() && enableAutoScroll) {
+            lazyColumnState.animateScrollToItem(index = filteredConsoleLogs.size - 1)
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        floatingActionButton = {
+            AnimatedVisibility(visible = !enableAutoScroll) {
+                FloatingActionButton(
+                    modifier = Modifier.testTag(tag = "scroll_to_bottom_button"),
+                    onClick = { enableAutoScroll = true }
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.ArrowDownward,
+                        contentDescription = "Resume auto-scroll"
+                    )
+                }
+            }
+        },
+        bottomBar = {
+            Surface {
+                Column {
+                    HorizontalDivider()
+                    FlowRow(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .animateContentSize(),
+                        horizontalArrangement = Arrangement.spacedBy(space = 8.dp)
+                    ) {
+                        LogLevel.entries.forEach { level ->
+                            val selected = selectedFilters[level] == true
+                            val levelColors = logColorScheme[level]
+                            FilterChip(
+                                modifier = Modifier.testTag(
+                                    tag = "console_level_chip_${level.name}"
+                                ),
+                                selected = selected,
+                                onClick = { selectedFilters[level] = !selected },
+                                border = FilterChipDefaults.filterChipBorder(
+                                    enabled = true,
+                                    selected = selected,
+                                    borderColor = levelColors.label
+                                ),
+                                colors = FilterChipDefaults.filterChipColors(
+                                    labelColor = levelColors.unselectedContent,
+                                    selectedLabelColor = levelColors.selectedContent,
+                                    selectedLeadingIconColor = levelColors.selectedContent,
+                                    selectedContainerColor = levelColors.selectedContainer
+                                ),
+                                leadingIcon = {
+                                    if (selected) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.Done,
+                                            contentDescription = null
+                                        )
+                                    }
+                                },
+                                label = { Text(text = level.name) }
+                            )
+                        }
+                    }
+                    HorizontalDivider()
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        OutlinedTextField(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp)
+                                .padding(bottom = bottomPadding)
+                                .testTag(tag = "console_filter_field"),
+                            value = filterQuery,
+                            onValueChange = { filterQuery = it },
+                            placeholder = { Text(text = "Filter by tag or message...") },
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Rounded.Search,
+                                    contentDescription = null
+                                )
+                            },
+                            trailingIcon = {
+                                AnimatedVisibility(visible = filterQuery.isNotEmpty()) {
+                                    IconButton(
+                                        modifier = Modifier.testTag(tag = "clear_filter_button"),
+                                        onClick = { filterQuery = "" }
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.Close,
+                                            contentDescription = "Clear filter"
+                                        )
+                                    }
+                                }
+                            },
+                            singleLine = true,
+                            shape = MaterialTheme.shapes.medium
+                        )
+                    }
+                }
+            }
+        }
+    ) { paddingValues ->
+        if (filteredConsoleLogs.isEmpty()) {
+            Text(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues = paddingValues)
+                    .padding(all = 16.dp)
+                    .testTag(tag = "console_empty_state"),
+                text = if (consoleLogs.isEmpty()) {
+                    "Console logs will appear here"
+                } else {
+                    "No logs match your filter"
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues = paddingValues)
+                    .imePadding()
+                    .nestedScroll(connection = nestedScrollConnection),
+                state = lazyColumnState,
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(space = 4.dp)
+            ) {
+                itemsIndexed(items = filteredConsoleLogs) { index, log ->
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(tag = "console_log_item_$index"),
+                        fontFamily = FontFamily.Monospace,
+                        style = MaterialTheme.typography.bodySmall,
+                        text = buildAnnotatedString {
+                            withStyle(
+                                style = SpanStyle(
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            ) {
+                                append(text = "${log.formattedTimestamp} ")
+                            }
+                            withStyle(style = SpanStyle(color = logColorScheme[log.level].label)) {
+                                if (log.tag.isNotEmpty()) {
+                                    append(text = "${log.tag}: ")
+                                }
+                                append(text = log.message)
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ConsoleScreenPreview(
+    @PreviewParameter(ConsoleLogListPreviewParameterProvider::class) consoleLogs: List<ConsoleLog>
+) {
+    MaterialTheme {
+        CompositionLocalProvider(
+            LocalConsoleLogs provides consoleLogs,
+            LocalLogColorScheme provides LogColorScheme.Light
+        ) {
+            ConsoleScreen(modifier = Modifier.fillMaxSize())
+        }
+    }
+}

--- a/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/DevViewLogWriter.kt
+++ b/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/DevViewLogWriter.kt
@@ -1,0 +1,53 @@
+package com.worldline.devview.consolelogger
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Severity
+import com.worldline.devview.consolelogger.model.ConsoleLog
+import com.worldline.devview.consolelogger.model.LogLevel
+import kotlin.time.Clock
+
+/**
+ * Optional [LogWriter] that forwards Kermit log calls to [ConsoleLogger].
+ *
+ * Native console capture (see [Console.captureNativeConsole]) cannot see `NSLog`/`os_log`/Swift
+ * `Logger` output on an iOS device with no debugger attached. Routing your app's logging
+ * through Kermit and registering this writer closes that gap on both platforms, since it
+ * runs in-process and does not depend on a debugger being attached:
+ *
+ * ```kotlin
+ * Logger.addLogWriter(DevViewLogWriter)
+ * ```
+ *
+ * ## Caveat
+ * On Android, if you *also* use Kermit's own `LogcatWriter`, entries logged through Kermit
+ * will appear twice in the Console module — once via this writer, once via the native
+ * logcat tail picking up what `LogcatWriter` already wrote. Use one or the other for a given
+ * log call, or accept the duplication.
+ *
+ * @see ConsoleLogger
+ */
+public object DevViewLogWriter : LogWriter() {
+    override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+        ConsoleLogger.log(
+            log = ConsoleLog(
+                level = severity.toLogLevel(),
+                tag = tag,
+                message = if (throwable != null) {
+                    "$message\n${throwable.stackTraceToString()}"
+                } else {
+                    message
+                },
+                timestamp = Clock.System.now().toEpochMilliseconds()
+            )
+        )
+    }
+}
+
+private fun Severity.toLogLevel(): LogLevel = when (this) {
+    Severity.Verbose -> LogLevel.VERBOSE
+    Severity.Debug -> LogLevel.DEBUG
+    Severity.Info -> LogLevel.INFO
+    Severity.Warn -> LogLevel.WARNING
+    Severity.Error -> LogLevel.ERROR
+    Severity.Assert -> LogLevel.ASSERT
+}

--- a/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/LogcatLine.kt
+++ b/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/LogcatLine.kt
@@ -1,0 +1,45 @@
+package com.worldline.devview.consolelogger
+
+import com.worldline.devview.consolelogger.model.ConsoleLog
+import com.worldline.devview.consolelogger.model.LogLevel
+import kotlin.time.Clock
+
+// Matches a single `logcat -v brief` line, e.g. `D/MyTag( 1234): message text`.
+// Group 1 is the one-letter priority, group 2 the tag, group 3 the message. Continuation
+// lines of a multi-line message don't match and fall back to LogLevel.UNKNOWN below.
+private val LOGCAT_BRIEF_LINE = Regex(pattern = """^([VDIWEF])/(.+?)\(\s*\d+\): (.*)$""")
+
+/**
+ * Parses a single line of `logcat -v brief` output into a [ConsoleLog].
+ *
+ * Lines that don't match the expected `<priority>/<tag>( <pid>): <message>` shape — such as
+ * continuation lines of a multi-line message — become a [LogLevel.UNKNOWN] entry carrying
+ * the raw line as its message, so nothing captured is silently dropped.
+ */
+internal fun parseLogcatLine(line: String): ConsoleLog {
+    val match = LOGCAT_BRIEF_LINE.matchEntire(input = line)
+        ?: return ConsoleLog(
+            level = LogLevel.UNKNOWN,
+            tag = "",
+            message = line,
+            timestamp = Clock.System.now().toEpochMilliseconds()
+        )
+
+    val (priority, tag, message) = match.destructured
+    return ConsoleLog(
+        level = priority.toLogLevel(),
+        tag = tag,
+        message = message,
+        timestamp = Clock.System.now().toEpochMilliseconds()
+    )
+}
+
+private fun String.toLogLevel(): LogLevel = when (this) {
+    "V" -> LogLevel.VERBOSE
+    "D" -> LogLevel.DEBUG
+    "I" -> LogLevel.INFO
+    "W" -> LogLevel.WARNING
+    "E" -> LogLevel.ERROR
+    "F" -> LogLevel.ASSERT
+    else -> LogLevel.UNKNOWN
+}

--- a/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/model/ConsoleLog.kt
+++ b/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/model/ConsoleLog.kt
@@ -1,0 +1,58 @@
+package com.worldline.devview.consolelogger.model
+
+import androidx.compose.runtime.Immutable
+import kotlin.time.Instant
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format
+import kotlinx.datetime.format.char
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Represents a single captured console log line.
+ *
+ * Instances are produced either by the platform-native capture layer (logcat on Android,
+ * a stdout/stderr redirect on iOS) or manually via
+ * [com.worldline.devview.consolelogger.ConsoleLogger.log].
+ *
+ * @property level The severity of this log line.
+ * @property tag The originating tag, e.g. an Android log tag. Empty when the source has no
+ *           concept of a tag (such as a raw stdout line on iOS).
+ * @property message The log message text.
+ * @property timestamp Unix timestamp in milliseconds representing when the line was captured.
+ *
+ * @see LogLevel
+ * @see com.worldline.devview.consolelogger.ConsoleLogger
+ */
+@Immutable
+public data class ConsoleLog(
+    val level: LogLevel,
+    val tag: String,
+    val message: String,
+    val timestamp: Long
+) {
+    private val instantTimestamp = Instant.fromEpochMilliseconds(epochMilliseconds = timestamp)
+
+    /**
+     * Returns the timestamp formatted as HH:mm:ss in the current system timezone.
+     *
+     * This property is used internally by the console UI to display line times in a
+     * human-readable format.
+     *
+     * @return A string representing the time in 24-hour format (e.g., "14:35:22").
+     */
+    internal val formattedTimestamp: String
+        get() = instantTimestamp
+            .toLocalDateTime(
+                timeZone = TimeZone.currentSystemDefault()
+            ).time
+            .format(
+                format = LocalTime.Format {
+                    hour()
+                    char(value = ':')
+                    minute()
+                    char(value = ':')
+                    second()
+                }
+            )
+}

--- a/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/model/LogLevel.kt
+++ b/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/model/LogLevel.kt
@@ -1,0 +1,37 @@
+package com.worldline.devview.consolelogger.model
+
+import androidx.compose.runtime.Stable
+
+/**
+ * Severity levels for a captured [ConsoleLog] entry.
+ *
+ * These mirror Android's `Log`/logcat priority levels, with [ASSERT] mapped from logcat's
+ * `F` ("What a Terrible Failure") priority and [UNKNOWN] reserved for lines the capture
+ * layer could not classify (e.g. continuation lines of a multi-line message).
+ *
+ * @see ConsoleLog
+ * @see com.worldline.devview.consolelogger.theme.LogColorScheme
+ */
+@Stable
+public enum class LogLevel {
+    /** Verbose diagnostic output; the lowest-priority, highest-volume level. */
+    VERBOSE,
+
+    /** Debug-only diagnostic output. */
+    DEBUG,
+
+    /** General informational messages. */
+    INFO,
+
+    /** Potentially harmful situations that do not stop execution. */
+    WARNING,
+
+    /** Error events that likely indicate a failure. */
+    ERROR,
+
+    /** Serious failures that should never happen ("What a Terrible Failure"). */
+    ASSERT,
+
+    /** A log line the capture layer could not classify into one of the levels above. */
+    UNKNOWN
+}

--- a/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/preview/ConsoleLogListPreviewParameterProvider.kt
+++ b/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/preview/ConsoleLogListPreviewParameterProvider.kt
@@ -1,0 +1,35 @@
+package com.worldline.devview.consolelogger.preview
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.worldline.devview.consolelogger.model.ConsoleLog
+import com.worldline.devview.consolelogger.model.LogLevel
+import kotlin.time.Clock
+
+/**
+ * Preview parameter provider for lists of [ConsoleLog] in composable previews.
+ *
+ * Generates a sample list of console logs containing one entry for each [LogLevel]. This is
+ * useful for previewing list-based UI components like the console screen with representative
+ * data across every level.
+ *
+ * @see ConsoleLog
+ * @see LogLevel
+ * @see com.worldline.devview.consolelogger.ConsoleScreen
+ */
+internal class ConsoleLogListPreviewParameterProvider : PreviewParameterProvider<List<ConsoleLog>> {
+    /**
+     * Provides a sequence containing a single list of sample [ConsoleLog] instances, with
+     * one log entry for each [LogLevel] variant.
+     */
+    override val values: Sequence<List<ConsoleLog>>
+        get() = sequenceOf(
+            element = LogLevel.entries.mapIndexed { index, level ->
+                ConsoleLog(
+                    level = level,
+                    tag = "SampleTag",
+                    message = "Sample $level message #$index",
+                    timestamp = Clock.System.now().toEpochMilliseconds()
+                )
+            }
+        )
+}

--- a/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/theme/LocalLogColorScheme.kt
+++ b/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/theme/LocalLogColorScheme.kt
@@ -1,0 +1,69 @@
+package com.worldline.devview.consolelogger.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.luminance
+import co.touchlab.kermit.Logger as KermitLogger
+
+/**
+ * CompositionLocal for providing the [LogColorScheme] used by the Console module's UI.
+ *
+ * Provide this where your app already configures its `MaterialTheme`, so the console
+ * palette switches alongside your light/dark theme:
+ *
+ * ```kotlin
+ * MaterialTheme(colorScheme = if (darkTheme) darkColorScheme() else lightColorScheme()) {
+ *     CompositionLocalProvider(
+ *         LocalLogColorScheme provides if (darkTheme) LogColorScheme.Dark else LogColorScheme.Light
+ *     ) {
+ *         // ... DevView content ...
+ *     }
+ * }
+ * ```
+ *
+ * If never provided, the console falls back to [LogColorScheme.Light]/[LogColorScheme.Dark]
+ * chosen from the ambient `MaterialTheme`'s surface luminance, and logs a one-time warning
+ * pointing at this CompositionLocal (see the "Theming" guide).
+ *
+ * @see LogColorScheme
+ */
+public val LocalLogColorScheme: ProvidableCompositionLocal<LogColorScheme?> =
+    staticCompositionLocalOf { null }
+
+// ponytail: plain top-level flag, not thread-safe under concurrent first compositions.
+// Guards a diagnostic log line, not app state — a rare duplicate warning is harmless.
+private var hasWarnedMissingLogColorScheme = false
+
+/**
+ * Resolves the [LogColorScheme] to use: [LocalLogColorScheme] if provided, otherwise a
+ * best-effort guess derived from the ambient `MaterialTheme`'s surface luminance.
+ *
+ * The luminance-based guess intentionally does not use `isSystemInDarkTheme()` — DevView
+ * renders inside the host app's `MaterialTheme`, which may be driven by something other
+ * than the system setting (e.g. a feature flag), so the theme actually in effect is the
+ * only reliable signal.
+ */
+@Composable
+@ReadOnlyComposable
+internal fun rememberLogColorScheme(): LogColorScheme {
+    val provided = LocalLogColorScheme.current
+    if (provided != null) return provided
+
+    if (!hasWarnedMissingLogColorScheme) {
+        hasWarnedMissingLogColorScheme = true
+        KermitLogger.w(tag = "DevViewConsole") {
+            "LocalLogColorScheme was never provided; falling back to a palette guessed " +
+                "from the current theme's surface luminance. Provide LocalLogColorScheme " +
+                "at your app's MaterialTheme site to fix this — see the Theming guide."
+        }
+    }
+
+    return if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) {
+        LogColorScheme.Dark
+    } else {
+        LogColorScheme.Light
+    }
+}

--- a/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/theme/LogColorScheme.kt
+++ b/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/theme/LogColorScheme.kt
@@ -1,0 +1,181 @@
+package com.worldline.devview.consolelogger.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import com.worldline.devview.consolelogger.model.LogLevel
+
+/**
+ * The set of colors used to render a single [LogLevel] in the console UI.
+ *
+ * @property label Color used for the log level's text/label, and for the message text of
+ *           log lines at this level.
+ * @property selectedContainer Background color of the level's filter chip when selected.
+ * @property selectedContent Content (icon/label) color of the level's filter chip when selected.
+ * @property unselectedContent Content (icon/label) color of the level's filter chip when
+ *           not selected.
+ *
+ * @see LogColorScheme
+ */
+@Immutable
+public data class LogLevelColors(
+    public val label: Color,
+    public val selectedContainer: Color,
+    public val selectedContent: Color,
+    public val unselectedContent: Color
+)
+
+/**
+ * The complete set of per-[LogLevel] colors used by the Console module's UI.
+ *
+ * DevView renders inside the host app's `MaterialTheme`, but log-level colors (a debug
+ * teal, a warning yellow, an error red, etc.) are intentionally not derived from
+ * `MaterialTheme.colorScheme` — they need to stay visually distinct and consistent
+ * regardless of the host's brand palette. [Light] and [Dark] are complete, hand-tuned
+ * palettes tested for contrast in each theme; use [copy] to override individual levels.
+ *
+ * ## Usage
+ *
+ * Provide the scheme where your app already configures its `MaterialTheme`, via
+ * [com.worldline.devview.consolelogger.theme.LocalLogColorScheme]:
+ *
+ * ```kotlin
+ * MaterialTheme(colorScheme = if (darkTheme) darkColorScheme() else lightColorScheme()) {
+ *     CompositionLocalProvider(
+ *         LocalLogColorScheme provides if (darkTheme) LogColorScheme.Dark else LogColorScheme.Light
+ *     ) {
+ *         // ...
+ *     }
+ * }
+ * ```
+ *
+ * ### Overriding individual levels
+ * ```kotlin
+ * LogColorScheme.Dark.copy(
+ *     error = LogColorScheme.Dark.error.copy(label = Color.Magenta)
+ * )
+ * ```
+ *
+ * @see LogLevelColors
+ * @see LocalLogColorScheme
+ */
+@Immutable
+public data class LogColorScheme(
+    public val verbose: LogLevelColors,
+    public val debug: LogLevelColors,
+    public val info: LogLevelColors,
+    public val warning: LogLevelColors,
+    public val error: LogLevelColors,
+    public val assert: LogLevelColors,
+    public val unknown: LogLevelColors
+) {
+    /**
+     * Returns the [LogLevelColors] for the given [level].
+     */
+    public operator fun get(level: LogLevel): LogLevelColors = when (level) {
+        LogLevel.VERBOSE -> verbose
+        LogLevel.DEBUG -> debug
+        LogLevel.INFO -> info
+        LogLevel.WARNING -> warning
+        LogLevel.ERROR -> error
+        LogLevel.ASSERT -> assert
+        LogLevel.UNKNOWN -> unknown
+    }
+
+    public companion object {
+        /**
+         * The default light-theme palette.
+         */
+        public val Light: LogColorScheme = LogColorScheme(
+            verbose = LogLevelColors(
+                label = Color(color = 0xFF616161),
+                selectedContainer = Color(color = 0xFFEBEBEB),
+                selectedContent = Color(color = 0xFF262626),
+                unselectedContent = Color(color = 0xFF262626)
+            ),
+            debug = LogLevelColors(
+                label = Color(color = 0xFF228181),
+                selectedContainer = Color(color = 0xFFAFE9E9),
+                selectedContent = Color(color = 0xFF0D3030),
+                unselectedContent = Color(color = 0xFF0D3030)
+            ),
+            info = LogLevelColors(
+                label = Color(color = 0xFF228129),
+                selectedContainer = Color(color = 0xFFB7ECBA),
+                selectedContent = Color(color = 0xFF103C13),
+                unselectedContent = Color(color = 0xFF103C13)
+            ),
+            warning = LogLevelColors(
+                label = Color(color = 0xFF837807),
+                selectedContainer = Color(color = 0xFFEFEBC2),
+                selectedContent = Color(color = 0xFF494304),
+                unselectedContent = Color(color = 0xFF494304)
+            ),
+            error = LogLevelColors(
+                label = Color(color = 0xFFCB4D2E),
+                selectedContainer = Color(color = 0xFFF1CAC1),
+                selectedContent = Color(color = 0xFF532013),
+                unselectedContent = Color(color = 0xFF532013)
+            ),
+            assert = LogLevelColors(
+                label = Color(color = 0xFF932999),
+                selectedContainer = Color(color = 0xFFEDC3EF),
+                selectedContent = Color(color = 0xFF432145),
+                unselectedContent = Color(color = 0xFF432145)
+            ),
+            unknown = LogLevelColors(
+                label = Color(color = 0xFF000000),
+                selectedContainer = Color(color = 0xFFD9D9D9),
+                selectedContent = Color(color = 0xFF000000),
+                unselectedContent = Color(color = 0xFF000000)
+            )
+        )
+
+        /**
+         * The default dark-theme palette.
+         */
+        public val Dark: LogColorScheme = LogColorScheme(
+            verbose = LogLevelColors(
+                label = Color(color = 0xFFB3B3B3),
+                selectedContainer = Color(color = 0xFFD1D1D1),
+                selectedContent = Color(color = 0xFF262626),
+                unselectedContent = Color(color = 0xFFD1D1D1)
+            ),
+            debug = LogLevelColors(
+                label = Color(color = 0xFF36C9C9),
+                selectedContainer = Color(color = 0xFF72D9D9),
+                selectedContent = Color(color = 0xFF0D3030),
+                unselectedContent = Color(color = 0xFF72D9D9)
+            ),
+            info = LogLevelColors(
+                label = Color(color = 0xFF36C940),
+                selectedContainer = Color(color = 0xFF72D979),
+                selectedContent = Color(color = 0xFF103C13),
+                unselectedContent = Color(color = 0xFF72D979)
+            ),
+            warning = LogLevelColors(
+                label = Color(color = 0xFFF3E225),
+                selectedContainer = Color(color = 0xFFF6E856),
+                selectedContent = Color(color = 0xFF272402),
+                unselectedContent = Color(color = 0xFFF6E856)
+            ),
+            error = LogLevelColors(
+                label = Color(color = 0xFFD56144),
+                selectedContainer = Color(color = 0xFFDE846D),
+                selectedContent = Color(color = 0xFF3E180E),
+                unselectedContent = Color(color = 0xFFDE846D)
+            ),
+            assert = LogLevelColors(
+                label = Color(color = 0xFFC84ACE),
+                selectedContainer = Color(color = 0xFFDA86DF),
+                selectedContent = Color(color = 0xFF432145),
+                unselectedContent = Color(color = 0xFFDA86DF)
+            ),
+            unknown = LogLevelColors(
+                label = Color(color = 0xFFFFFFFF),
+                selectedContainer = Color(color = 0xFFFFFFFF),
+                selectedContent = Color(color = 0xFF000000),
+                unselectedContent = Color(color = 0xFFFFFFFF)
+            )
+        )
+    }
+}

--- a/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/theme/LogColorScheme.kt
+++ b/devview-consolelogger/src/commonMain/kotlin/com/worldline/devview/consolelogger/theme/LogColorScheme.kt
@@ -55,6 +55,14 @@ public data class LogLevelColors(
  * )
  * ```
  *
+ * @property verbose Colors for [LogLevel.VERBOSE].
+ * @property debug Colors for [LogLevel.DEBUG].
+ * @property info Colors for [LogLevel.INFO].
+ * @property warning Colors for [LogLevel.WARNING].
+ * @property error Colors for [LogLevel.ERROR].
+ * @property assert Colors for [LogLevel.ASSERT].
+ * @property unknown Colors for [LogLevel.UNKNOWN].
+ *
  * @see LogLevelColors
  * @see LocalLogColorScheme
  */

--- a/devview-consolelogger/src/commonTest/kotlin/com/worldline/devview/consolelogger/ConsoleLoggerTest.kt
+++ b/devview-consolelogger/src/commonTest/kotlin/com/worldline/devview/consolelogger/ConsoleLoggerTest.kt
@@ -1,0 +1,84 @@
+package com.worldline.devview.consolelogger
+
+import com.worldline.devview.consolelogger.model.ConsoleLog
+import com.worldline.devview.consolelogger.model.LogLevel
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+class ConsoleLoggerTest {
+
+    @AfterTest
+    fun tearDown() {
+        ConsoleLogger.clear()
+        ConsoleLogger.configure(maxEntries = ConsoleLogger.DEFAULT_MAX_ENTRIES)
+    }
+
+    @Test
+    fun `log entries are drained into logs in order`() = runTest {
+        ConsoleLogger.configure(maxEntries = 10)
+        val job = launch { ConsoleLogger.collectInto() }
+
+        ConsoleLogger.log(log = testLog(message = "first"))
+        ConsoleLogger.log(log = testLog(message = "second"))
+        advanceUntilIdle()
+
+        ConsoleLogger.logs.map { it.message } shouldContainExactly listOf("first", "second")
+        ConsoleLogger.hasLogs shouldBe true
+
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `oldest entries are evicted past maxEntries`() = runTest {
+        ConsoleLogger.configure(maxEntries = 2)
+        val job = launch { ConsoleLogger.collectInto() }
+
+        ConsoleLogger.log(log = testLog(message = "first"))
+        ConsoleLogger.log(log = testLog(message = "second"))
+        ConsoleLogger.log(log = testLog(message = "third"))
+        advanceUntilIdle()
+
+        ConsoleLogger.logs shouldHaveSize 2
+        ConsoleLogger.logs.map { it.message } shouldContainExactly listOf("second", "third")
+
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `clear removes all logged entries`() = runTest {
+        ConsoleLogger.configure(maxEntries = 10)
+        val job = launch { ConsoleLogger.collectInto() }
+
+        ConsoleLogger.log(log = testLog(message = "only"))
+        advanceUntilIdle()
+
+        ConsoleLogger.clear()
+
+        ConsoleLogger.hasLogs shouldBe false
+        ConsoleLogger.logs shouldHaveSize 0
+
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `configure rejects non-positive maxEntries`() {
+        shouldThrow<IllegalArgumentException> {
+            ConsoleLogger.configure(maxEntries = 0)
+        }
+    }
+
+    private fun testLog(message: String): ConsoleLog = ConsoleLog(
+        level = LogLevel.INFO,
+        tag = "Test",
+        message = message,
+        timestamp = 1_700_000_000_000
+    )
+}

--- a/devview-consolelogger/src/commonTest/kotlin/com/worldline/devview/consolelogger/ConsoleModuleTest.kt
+++ b/devview-consolelogger/src/commonTest/kotlin/com/worldline/devview/consolelogger/ConsoleModuleTest.kt
@@ -1,0 +1,67 @@
+package com.worldline.devview.consolelogger
+
+import com.worldline.devview.consolelogger.model.ConsoleLog
+import com.worldline.devview.consolelogger.model.LogLevel
+import com.worldline.devview.core.Section
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+class ConsoleModuleTest {
+
+    @AfterTest
+    fun tearDown() {
+        ConsoleLogger.clear()
+    }
+
+    @Test
+    fun `console module exposes expected metadata and destination action`() {
+        val module = Console()
+
+        module.section shouldBe Section.LOGGING
+        module.destinations.keys.shouldContain(ConsoleDestination.Main::class)
+        module.entryDestination::class shouldBe ConsoleDestination.Main::class
+
+        val mainMetadata = module.destinations[ConsoleDestination.Main::class].shouldNotBeNull()
+
+        mainMetadata.title shouldBe "Console"
+        mainMetadata.actions shouldHaveSize 1
+
+        val clearAction = mainMetadata.actions.single()
+
+        clearAction.popup.shouldNotBeNull().apply {
+            title shouldBe "Clear Logs"
+            confirmButton shouldBe "Clear"
+            dismissButton shouldBe "Cancel"
+        }
+    }
+
+    @Test
+    fun `clear action removes existing logs`() {
+        val module = Console()
+
+        val clearAction = module.destinations[ConsoleDestination.Main::class]
+            .shouldNotBeNull()
+            .actions
+            .single()
+
+        ConsoleLogger.logs.add(
+            ConsoleLog(level = LogLevel.INFO, tag = "tag", message = "message", timestamp = 1_700_000_000_000)
+        )
+
+        clearAction.action()
+
+        ConsoleLogger.hasLogs shouldBe false
+    }
+
+    @Test
+    fun `constructor keeps maxEntries and captureNativeConsole`() {
+        val module = Console(maxEntries = 42, captureNativeConsole = false)
+
+        module.maxEntries shouldBe 42
+        module.captureNativeConsole shouldBe false
+    }
+}

--- a/devview-consolelogger/src/commonTest/kotlin/com/worldline/devview/consolelogger/DevViewLogWriterTest.kt
+++ b/devview-consolelogger/src/commonTest/kotlin/com/worldline/devview/consolelogger/DevViewLogWriterTest.kt
@@ -1,0 +1,79 @@
+package com.worldline.devview.consolelogger
+
+import co.touchlab.kermit.Severity
+import com.worldline.devview.consolelogger.model.LogLevel
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+class DevViewLogWriterTest {
+
+    @AfterTest
+    fun tearDown() {
+        ConsoleLogger.clear()
+        ConsoleLogger.configure(maxEntries = ConsoleLogger.DEFAULT_MAX_ENTRIES)
+    }
+
+    @Test
+    fun `every Severity maps to its LogLevel`() = runTest {
+        ConsoleLogger.configure(maxEntries = 10)
+        val job = launch { ConsoleLogger.collectInto() }
+
+        val expected = mapOf(
+            Severity.Verbose to LogLevel.VERBOSE,
+            Severity.Debug to LogLevel.DEBUG,
+            Severity.Info to LogLevel.INFO,
+            Severity.Warn to LogLevel.WARNING,
+            Severity.Error to LogLevel.ERROR,
+            Severity.Assert to LogLevel.ASSERT
+        )
+
+        expected.forEach { (severity, _) ->
+            DevViewLogWriter.log(severity = severity, message = "message", tag = "MyTag", throwable = null)
+        }
+        advanceUntilIdle()
+
+        ConsoleLogger.logs.map { it.level } shouldBe expected.values.toList()
+
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `message without a throwable is forwarded unchanged`() = runTest {
+        ConsoleLogger.configure(maxEntries = 10)
+        val job = launch { ConsoleLogger.collectInto() }
+
+        DevViewLogWriter.log(severity = Severity.Info, message = "plain message", tag = "Tag", throwable = null)
+        advanceUntilIdle()
+
+        val log = ConsoleLogger.logs.single()
+        log.message shouldBe "plain message"
+        log.tag shouldBe "Tag"
+        log.message.shouldNotContain("\n")
+
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `throwable stack trace is appended to the message`() = runTest {
+        ConsoleLogger.configure(maxEntries = 10)
+        val job = launch { ConsoleLogger.collectInto() }
+        val throwable = IllegalStateException("boom")
+
+        DevViewLogWriter.log(severity = Severity.Error, message = "failed", tag = "Tag", throwable = throwable)
+        advanceUntilIdle()
+
+        val log = ConsoleLogger.logs.single()
+        log.message.shouldContain("failed")
+        log.message.shouldContain("IllegalStateException")
+        log.message.shouldContain("boom")
+
+        job.cancelAndJoin()
+    }
+}

--- a/devview-consolelogger/src/commonTest/kotlin/com/worldline/devview/consolelogger/LogcatLineTest.kt
+++ b/devview-consolelogger/src/commonTest/kotlin/com/worldline/devview/consolelogger/LogcatLineTest.kt
@@ -1,0 +1,54 @@
+package com.worldline.devview.consolelogger
+
+import com.worldline.devview.consolelogger.model.LogLevel
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class LogcatLineTest {
+
+    @Test
+    fun `every priority prefix maps to its LogLevel`() {
+        val expected = mapOf(
+            "V" to LogLevel.VERBOSE,
+            "D" to LogLevel.DEBUG,
+            "I" to LogLevel.INFO,
+            "W" to LogLevel.WARNING,
+            "E" to LogLevel.ERROR,
+            "F" to LogLevel.ASSERT
+        )
+
+        expected.forEach { (priority, level) ->
+            val log = parseLogcatLine(line = "$priority/MyTag( 1234): something happened")
+
+            log.level shouldBe level
+            log.tag shouldBe "MyTag"
+            log.message shouldBe "something happened"
+        }
+    }
+
+    @Test
+    fun `tag containing spaces is preserved`() {
+        val log = parseLogcatLine(line = "D/My Cool Tag( 42): hello")
+
+        log.tag shouldBe "My Cool Tag"
+        log.message shouldBe "hello"
+    }
+
+    @Test
+    fun `message containing the delimiter sequence is preserved in full`() {
+        val log = parseLogcatLine(line = "I/Tag( 1): result): still part of the message")
+
+        log.message shouldBe "result): still part of the message"
+    }
+
+    @Test
+    fun `unparseable line becomes UNKNOWN with the raw line as message`() {
+        val line = "    at com.example.Foo.bar(Foo.kt:42)"
+
+        val log = parseLogcatLine(line = line)
+
+        log.level shouldBe LogLevel.UNKNOWN
+        log.tag shouldBe ""
+        log.message shouldBe line
+    }
+}

--- a/devview-consolelogger/src/commonTest/kotlin/com/worldline/devview/consolelogger/theme/LogColorSchemeTest.kt
+++ b/devview-consolelogger/src/commonTest/kotlin/com/worldline/devview/consolelogger/theme/LogColorSchemeTest.kt
@@ -1,0 +1,38 @@
+package com.worldline.devview.consolelogger.theme
+
+import androidx.compose.ui.graphics.Color
+import com.worldline.devview.consolelogger.model.LogLevel
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class LogColorSchemeTest {
+
+    @Test
+    fun `get returns the matching slot for every level`() {
+        val scheme = LogColorScheme.Light
+
+        scheme[LogLevel.VERBOSE] shouldBe scheme.verbose
+        scheme[LogLevel.DEBUG] shouldBe scheme.debug
+        scheme[LogLevel.INFO] shouldBe scheme.info
+        scheme[LogLevel.WARNING] shouldBe scheme.warning
+        scheme[LogLevel.ERROR] shouldBe scheme.error
+        scheme[LogLevel.ASSERT] shouldBe scheme.assert
+        scheme[LogLevel.UNKNOWN] shouldBe scheme.unknown
+    }
+
+    @Test
+    fun `copy of one level leaves the others untouched`() {
+        val original = LogColorScheme.Dark
+        val overridden = original.copy(
+            error = original.error.copy(label = Color.Magenta)
+        )
+
+        overridden.error.label shouldBe Color.Magenta
+        overridden.verbose shouldBe original.verbose
+        overridden.debug shouldBe original.debug
+        overridden.info shouldBe original.info
+        overridden.warning shouldBe original.warning
+        overridden.assert shouldBe original.assert
+        overridden.unknown shouldBe original.unknown
+    }
+}

--- a/devview-consolelogger/src/iosMain/kotlin/com/worldline/devview/consolelogger/ConsoleCapture.ios.kt
+++ b/devview-consolelogger/src/iosMain/kotlin/com/worldline/devview/consolelogger/ConsoleCapture.ios.kt
@@ -12,6 +12,7 @@ import kotlinx.cinterop.get
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.usePinned
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive

--- a/devview-consolelogger/src/iosMain/kotlin/com/worldline/devview/consolelogger/ConsoleCapture.ios.kt
+++ b/devview-consolelogger/src/iosMain/kotlin/com/worldline/devview/consolelogger/ConsoleCapture.ios.kt
@@ -1,0 +1,112 @@
+package com.worldline.devview.consolelogger
+
+import com.worldline.devview.consolelogger.model.ConsoleLog
+import com.worldline.devview.consolelogger.model.LogLevel
+import kotlin.time.Clock
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.IntVar
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import platform.posix.F_SETFL
+import platform.posix.O_NONBLOCK
+import platform.posix.STDERR_FILENO
+import platform.posix.STDOUT_FILENO
+import platform.posix._IOLBF
+import platform.posix.close
+import platform.posix.dup
+import platform.posix.dup2
+import platform.posix.fcntl
+import platform.posix.pipe
+import platform.posix.read
+import platform.posix.setvbuf
+import platform.posix.stdout
+import platform.posix.write
+
+private const val READ_BUFFER_SIZE = 4096
+
+/**
+ * Redirects `stdout` and `stderr` through in-process pipes so Kotlin `println`, Swift
+ * `print`, and C `printf` output reaches [ConsoleLogger] even when no debugger is
+ * attached. Bytes are teed back to the original file descriptor so Xcode's console still
+ * shows everything when the device is tethered.
+ *
+ * This cannot see `NSLog`/`os_log`/Swift `Logger` output on a device with no debugger
+ * attached — those bypass the file descriptor entirely. See [DevViewLogWriter] to close
+ * that gap for logging routed through Kermit.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal actual suspend fun tailNativeConsole(): Unit = coroutineScope {
+    launch { redirectStream(fd = STDOUT_FILENO, level = LogLevel.INFO) }
+    launch { redirectStream(fd = STDERR_FILENO, level = LogLevel.ERROR) }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private suspend fun redirectStream(fd: Int, level: LogLevel): Unit = withContext(Dispatchers.IO) {
+    val saved = dup(fd)
+    val (readFd, writeFd) = memScoped {
+        val fds = allocArray<IntVar>(2)
+        pipe(fds)
+        fds[0] to fds[1]
+    }
+
+    dup2(writeFd, fd)
+    close(writeFd)
+
+    // Non-blocking so a stalled reader (a full pipe buffer) drops writes instead of
+    // hanging every subsequent print in the app that owns this file descriptor. Dropping
+    // log lines is the correct trade for a dev tool.
+    fcntl(fd, F_SETFL, O_NONBLOCK)
+
+    if (fd == STDOUT_FILENO) {
+        // A pipe is not a tty, so libc switches stdout to 4KB full buffering and lines
+        // would arrive in bursts. Line-buffer instead so each println flushes promptly.
+        setvbuf(stdout, null, _IOLBF, 0.convert())
+    }
+
+    val buffer = ByteArray(size = READ_BUFFER_SIZE)
+    var pending = ""
+    try {
+        while (true) {
+            currentCoroutineContext().ensureActive()
+
+            val bytesRead = buffer.usePinned { pinned ->
+                read(readFd, pinned.addressOf(index = 0), buffer.size.convert())
+            }
+            if (bytesRead <= 0) break
+
+            buffer.usePinned { pinned ->
+                write(saved, pinned.addressOf(index = 0), bytesRead.convert())
+            }
+
+            pending += buffer.decodeToString(endIndex = bytesRead.toInt())
+            val lines = pending.split("\n")
+            pending = lines.last()
+            lines.dropLast(n = 1).forEach { line ->
+                if (line.isNotEmpty()) {
+                    ConsoleLogger.log(
+                        log = ConsoleLog(
+                            level = level,
+                            tag = "",
+                            message = line,
+                            timestamp = Clock.System.now().toEpochMilliseconds()
+                        )
+                    )
+                }
+            }
+        }
+    } finally {
+        close(readFd)
+        dup2(saved, fd)
+        close(saved)
+    }
+}

--- a/devview/build.gradle.kts
+++ b/devview/build.gradle.kts
@@ -45,6 +45,7 @@ compose {
 
 dependencies {
     kover(projects.devviewAnalytics)
+    kover(projects.devviewConsolelogger)
     kover(projects.devviewFeatureflip)
     kover(projects.devviewTimecapsule)
     kover(projects.devviewNetworkmock)

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -37,6 +37,43 @@ module's `Section` palette colors. Each section has its own brand-palette tint:
 
 You only need to override `containerColor`/`contentColor` if your module requires a color outside its section's default.
 
+## Console Log Level Colors
+
+Unlike most of DevView, the Console Logger module's per-[`LogLevel`](../modules/consolelogger.md)
+colors (a debug teal, a warning yellow, an error red, etc.) are **not** derived from
+`MaterialTheme.colorScheme` — they are two complete, hand-tuned palettes (`LogColorScheme.Light`
+and `LogColorScheme.Dark`) chosen for contrast and consistency regardless of your app's brand
+colors.
+
+Provide the palette where you already configure your app's `MaterialTheme`, so it switches
+alongside your light/dark theme:
+
+```kotlin
+MaterialTheme(colorScheme = if (darkTheme) darkColorScheme() else lightColorScheme()) {
+    CompositionLocalProvider(
+        LocalLogColorScheme provides if (darkTheme) LogColorScheme.Dark else LogColorScheme.Light
+    ) {
+        // ... DevView content ...
+    }
+}
+```
+
+Override individual levels with `copy()`:
+
+```kotlin
+LogColorScheme.Dark.copy(
+    error = LogColorScheme.Dark.error.copy(label = Color.Magenta)
+)
+```
+
+**If `LocalLogColorScheme` is never provided**, the console logs a one-time warning (tag
+`DevViewConsole`) and falls back to `LogColorScheme.Light`/`LogColorScheme.Dark` guessed from
+the ambient `MaterialTheme`'s surface luminance — usually correct, but the warning is your cue
+to wire up `LocalLogColorScheme` explicitly. The fallback deliberately does not use
+`isSystemInDarkTheme()`, since DevView's theme may be driven by something other than the
+system setting (e.g. a feature flag), and the theme actually in effect is the only reliable
+signal.
+
 ## Customising Typography
 Use your app's typography settings in custom modules:
 ```kotlin

--- a/docs/modules/consolelogger.md
+++ b/docs/modules/consolelogger.md
@@ -1,0 +1,119 @@
+# Console Logger Module
+
+Displays the app's native console output inside the DevView overlay — logcat on Android, a
+`stdout`/`stderr` redirect on iOS — like viewing Logcat in Android Studio, with per-level
+filter chips and a text filter.
+
+## Overview
+
+Native capture works on an **untethered** device — no debugger required — which is the
+main requirement this module is built around: a tester installs a release build and opens
+DevView without ever plugging into a computer.
+
+| Log source | Android | iOS |
+|---|---|---|
+| `android.util.Log` (incl. third-party libs) | ✅ logcat tail | n/a |
+| Kotlin `println` | ✅ (ART redirects stdout → logcat) | ✅ stdout pipe |
+| Swift `print`, C `printf` | n/a | ✅ stdout pipe |
+| `NSLog` / `os_log` / Swift `Logger` | n/a | ❌ **not capturable** |
+| Kermit, via `DevViewLogWriter` | ✅ | ✅ (in-process, no debugger needed) |
+
+The one real gap is `NSLog`/`os_log` on iOS: since iOS 10, `NSLog` only reaches `stderr`
+when a debugger is attached, and `os_log`/Swift `Logger` bypass the file descriptor
+entirely. Closing that gap fully would require reading the unified log via `OSLogStore`,
+which needs an `@objc` Swift shim and cinterop wiring — out of scope for now. The practical
+mitigation is `DevViewLogWriter` (see below): route your app's logging through Kermit and
+it reaches the console reliably on both platforms, tethered or not.
+
+Retained history is bounded (default 1000 entries, oldest evicted first) so a logcat-speed
+firehose can't grow memory unbounded.
+
+## Installation
+
+```kotlin
+dependencies {
+    implementation("com.worldline.devview:devview-consolelogger:<version>")
+}
+```
+
+## Core API
+
+### `Console`
+
+The DevView module:
+
+```kotlin
+public class Console(
+    public val maxEntries: Int = ConsoleLogger.DEFAULT_MAX_ENTRIES,
+    public val captureNativeConsole: Boolean = true
+)
+```
+
+```kotlin
+val modules = rememberModules {
+    module(Console())
+}
+```
+
+Set `captureNativeConsole = false` to disable the native tail and only show entries logged
+manually via `ConsoleLogger.log()` or `DevViewLogWriter`.
+
+### `ConsoleLogger`
+
+The log sink, in the same shape as `AnalyticsLogger`:
+
+```kotlin
+public object ConsoleLogger {
+    public fun log(log: ConsoleLog)
+    public val logs: SnapshotStateList<ConsoleLog>
+    public val hasLogs: Boolean
+}
+```
+
+`log()` is safe to call from any thread, including the background thread(s) driving native
+capture.
+
+### `DevViewLogWriter`
+
+An optional [Kermit](https://github.com/touchlab/kermit) `LogWriter` that forwards
+structured log calls into the same sink:
+
+```kotlin
+Logger.addLogWriter(DevViewLogWriter)
+```
+
+This is the reliable way to see logs on an iOS device with no debugger attached. On
+Android, using this **alongside** Kermit's own `LogcatWriter` will show each entry twice —
+once via this writer, once via the native logcat tail picking up what `LogcatWriter` wrote.
+Use one or the other for a given log call, or accept the duplication.
+
+## Theming
+
+Log-level colors (a debug teal, a warning yellow, an error red, etc.) are a fixed,
+hand-tuned palette per theme, not derived from `MaterialTheme.colorScheme` — see the
+[Theming guide](../guides/theming.md#console-log-level-colors) for how to provide and
+override them.
+
+## Usage
+
+```kotlin
+val modules = rememberModules {
+    module(Console())
+}
+
+// Optional: route Kermit-based logging into the same view.
+Logger.addLogWriter(DevViewLogWriter)
+```
+
+Opening DevView → Console shows captured lines tailing live, colored by level. Selecting
+one or more level chips filters to just those levels; selecting none shows everything.
+Typing in the filter field matches against both tag and message. Scrolling up disables
+auto-follow; a floating action button jumps back to the latest entry and resumes it.
+
+## Sample
+
+See `sample/shared/.../DevViewApp.kt` for a runnable end-to-end example, including
+`LocalLogColorScheme` wired to the sample's dark-mode toggle.
+
+## API Reference
+> _[Dokka API Reference](../api/devview-consolelogger/index.html)_

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -9,6 +9,7 @@ DevView uses a modular architecture where each module provides specific develope
 | Core           | Foundation, navigation, module system                                            | Always required            |
 | FeatureFlip    | Feature flag management (local/remote), persistent state, search/filter UI       | [Learn more ->](featureflip.md) |
 | Analytics      | Real-time analytics event monitoring, event logging, tabular display, filtering  | [Learn more ->](analytics.md)   |
+| Console Logger | Native console output (logcat/stdout) in-app, untethered, with level filters and text search | [Learn more ->](consolelogger.md) |
 | TimeCapsule    | Per-screen state history with restore, resets on navigation                       | [Learn more ->](timecapsule.md) |
 | NetworkMock    | Mock network requests/responses, UI for toggling mocks, Ktor plugin integration  | [Learn more ->](networkmock.md) |
 | Custom Modules | Extend DevView with your own developer tools                                     | [Creating Custom Modules ->](custom-modules.md) |
@@ -17,6 +18,7 @@ DevView uses a modular architecture where each module provides specific develope
 - **Core:** Required for all DevView functionality.
 - **FeatureFlip:** Use for dynamic feature toggling.
 - **Analytics:** Use for monitoring and debugging analytics events.
+- **Console Logger:** Use to view native console output (logcat/stdout) in-app on a device with no debugger attached.
 - **TimeCapsule:** Use to capture and replay recent app states during debugging.
 - **NetworkMock:** Use for simulating network responses, testing error handling, or developing offline features.
 - **Custom Modules:** Use for bespoke developer tools tailored to your workflow.
@@ -29,12 +31,14 @@ graph LR
     A --> D[TimeCapsule]
     A --> E[NetworkMock]
     A --> F[Custom Modules]
+    A --> L[Console Logger]
     B --> G[DataStore]
     E --> G
     C --> H[Event Logger]
     D --> I[State Timeline]
     E --> J[Mock Engine]
     F --> K[Your Tools]
+    L --> M[Native Console Capture]
 ```
 
 DevView modules are plug-and-play, integrating seamlessly with the core. Modules can be conditionally enabled based on build type, feature flags, or other criteria.
@@ -44,6 +48,7 @@ DevView modules are plug-and-play, integrating seamlessly with the core. Modules
 val modules = rememberModules {
     module(FeatureFlip)
     module(Analytics())
+    module(Console())
     module(TimeCapsule)
     module(NetworkMock(resourceLoader = NetworkMockResourceLoader { path -> Res.readBytes(path) }))
     module(MyCustomModule)

--- a/internal/dokka/build.gradle.kts
+++ b/internal/dokka/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
 dependencies {
     dokka(projects.devview)
     dokka(projects.devviewAnalytics)
+    dokka(projects.devviewConsolelogger)
     dokka(projects.devviewFeatureflip)
     dokka(projects.devviewTimecapsule)
     dokka(projects.devviewNetworkmock)

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -43,6 +43,7 @@ kotlin {
             implementation(projects.devview)
             implementation(projects.devviewFeatureflip)
             implementation(projects.devviewAnalytics)
+            implementation(projects.devviewConsolelogger)
             implementation(projects.devviewTimecapsule)
             implementation(projects.devviewNetworkmock)
             implementation(projects.devviewUtils)

--- a/sample/shared/src/commonMain/kotlin/com/worldline/devview/sample/DevViewApp.kt
+++ b/sample/shared/src/commonMain/kotlin/com/worldline/devview/sample/DevViewApp.kt
@@ -6,17 +6,25 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.Color
+import co.touchlab.kermit.Logger
 import com.worldline.devview.DevView
 import com.worldline.devview.analytics.Analytics
 import com.worldline.devview.analytics.AnalyticsLogger
 import com.worldline.devview.analytics.LocalAnalytics
 import com.worldline.devview.analytics.model.AnalyticsLog
 import com.worldline.devview.analytics.model.AnalyticsLogType
+import com.worldline.devview.consolelogger.Console
+import com.worldline.devview.consolelogger.ConsoleLogger
+import com.worldline.devview.consolelogger.DevViewLogWriter
+import com.worldline.devview.consolelogger.LocalConsoleLogs
+import com.worldline.devview.consolelogger.theme.LocalLogColorScheme
+import com.worldline.devview.consolelogger.theme.LogColorScheme
 import com.worldline.devview.core.rememberModules
 import com.worldline.devview.featureflip.FeatureFlip
 import com.worldline.devview.featureflip.model.Feature
@@ -46,6 +54,7 @@ public fun DevViewApp() {
     val modules = rememberModules {
         module(module = FeatureFlip)
         module(module = Analytics())
+        module(module = Console())
         module(module = TimeCapsule)
         module(
             module = NetworkMock(
@@ -92,9 +101,19 @@ public fun DevViewApp() {
         )
     }
 
+    // Route Kermit-based logging (e.g. sample:network's HTTP client logging) into the
+    // Console module, closing the gap native capture can't reach on iOS (NSLog/os_log
+    // with no debugger attached). Registered once — Logger.addLogWriter is not
+    // idempotent, so this must not re-run on every recomposition.
+    val consoleLogs = remember { ConsoleLogger.logs }
+    LaunchedEffect(key1 = Unit) {
+        Logger.addLogWriter(DevViewLogWriter)
+    }
+
     CompositionLocalProvider(
         LocalFeatureHandler provides featureHandler,
-        LocalAnalytics provides analytics
+        LocalAnalytics provides analytics,
+        LocalConsoleLogs provides consoleLogs
     ) {
         val localFeatureHandler = LocalFeatureHandler.current
 
@@ -170,18 +189,27 @@ public fun DevViewApp() {
         MaterialTheme(
             colorScheme = colorScheme
         ) {
-            // DevView open/close state
-            var devViewOpen by remember { mutableStateOf(value = false) }
+            // Chosen here, alongside the MaterialTheme colorScheme above, rather than as
+            // a Console constructor param: this stays reactive to the darkMode toggle,
+            // and rememberModules() (where Console is constructed) runs before darkMode
+            // is readable.
+            CompositionLocalProvider(
+                value = LocalLogColorScheme provides
+                    if (darkMode) LogColorScheme.Dark else LogColorScheme.Light
+            ) {
+                // DevView open/close state
+                var devViewOpen by remember { mutableStateOf(value = false) }
 
-            // Main app content
-            App(openDevView = { devViewOpen = it })
+                // Main app content
+                App(openDevView = { devViewOpen = it })
 
-            // DevView overlay
-            DevView(
-                devViewIsOpen = devViewOpen,
-                closeDevView = { devViewOpen = false },
-                modules = modules
-            )
+                // DevView overlay
+                DevView(
+                    devViewIsOpen = devViewOpen,
+                    closeDevView = { devViewOpen = false },
+                    modules = modules
+                )
+            }
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,7 @@ rootProject.name = "devview-root"
 include(
     ":devview",
     ":devview-analytics",
+    ":devview-consolelogger",
     ":devview-featureflip",
     ":devview-timecapsule",
     ":devview-networkmock",

--- a/zensical.toml
+++ b/zensical.toml
@@ -69,6 +69,7 @@ nav = [
     "modules/index.md",
     { "FeatureFlip" = "modules/featureflip.md" },
     { "Analytics" = "modules/analytics.md" },
+    { "Console Logger" = "modules/consolelogger.md" },
     { "TimeCapsule" = "modules/timecapsule.md" },
     { "NetworkMock" = [
       { "Overview" = "modules/networkmock.md" },


### PR DESCRIPTION
## Summary
- Adds `devview-consolelogger`: an in-app viewer for the device's native console output (logcat on Android, a stdout/stderr redirect on iOS), with per-level filter chips, text search, and auto-follow — closes #41.
- Native capture works on an **untethered** device on both platforms (no debugger required), which was the key requirement — see the capture matrix and the one known gap (`NSLog`/`os_log` on iOS with no debugger) in `docs/modules/consolelogger.md`.
- An optional `DevViewLogWriter` routes Kermit-based logging into the same view, closing that iOS gap for apps that log through Kermit.
- Log-level colors are a fixed, hand-tuned palette (ported from a prior Android-only implementation) overridable via a `LocalLogColorScheme` CompositionLocal at the host's theme site, with a warn-once + theme-luminance fallback.
- Wired into the sample app and documented (module page, theming guide, module `CLAUDE.md`, README, CHANGELOG).

## Test plan
- [x] `:devview-consolelogger:testAndroidHostTest` — 16 unit tests pass (sink ring-buffer eviction, logcat line parsing, Kermit severity mapping, module metadata, color scheme lookup/copy)
- [x] `:konsist:test` — architecture rules pass
- [x] `detektFull` — clean project-wide
- [x] `:sample:androidApp:assembleDebug` — builds successfully
- [x] `:devview-consolelogger:metalavaGenerateSignature` — API surface recorded in `devview-consolelogger/api/api.txt`
- [ ] CI `ios-build` job (`compileKotlinIosArm64 iosSimulatorArm64Test`) — the iOS `actual` (posix pipe redirect) can't be compiled from this Windows dev machine; needs the `macos-26` CI runner to verify
- [ ] Android instrumented tests (`connectedAndroidDeviceTest`) — no emulator/device available locally
- [ ] Manual on-device verification (Android + iOS, tethered and untethered) — see `docs/modules/consolelogger.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)