### PR TITLE
fix: repair release automation and align with upstream haze scripts

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: 3.x
 
       - name: Install dependencies
-        run: pip install zensical==0.0.50 git+https://github.com/squidfunk/mike.git
+        run: pip install -r pip-requirements.txt
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -63,20 +63,42 @@ jobs:
       - name: Resolve docs deployment
         id: docs
         env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_ALIASES: ${{ inputs.aliases }}
           VERSION_NAME: ${{ steps.version_name.outputs.VERSION_NAME }}
         run: |
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            docs_version="${{ inputs.version }}"
-            docs_aliases="${{ inputs.aliases }}"
+            docs_version="$INPUT_VERSION"
+            docs_aliases="$INPUT_ALIASES"
           elif echo "$VERSION_NAME" | grep -q "SNAPSHOT"; then
             docs_version="dev"
+            docs_aliases=""
+          elif echo "$VERSION_NAME" | grep -q -- "-"; then
+            # Pre-release (e.g. 0.3.0-alpha01): deploy under its own version, never 'latest'.
+            docs_version="$VERSION_NAME"
             docs_aliases=""
           else
             docs_version="$VERSION_NAME"
             docs_aliases="latest"
           fi
-          echo "version=$docs_version" >> $GITHUB_OUTPUT
-          echo "aliases=$docs_aliases" >> $GITHUB_OUTPUT
+
+          case "$docs_version" in
+            *[!a-zA-Z0-9._-]*)
+              echo "Docs version contains invalid characters: $docs_version"
+              exit 1
+              ;;
+          esac
+          for docs_alias in $docs_aliases; do
+            case "$docs_alias" in
+              *[!a-zA-Z0-9._-]*)
+                echo "Docs alias contains invalid characters: $docs_alias"
+                exit 1
+                ;;
+            esac
+          done
+
+          echo "version=$docs_version" >> "$GITHUB_OUTPUT"
+          echo "aliases=$docs_aliases" >> "$GITHUB_OUTPUT"
           echo "Resolved: version=$docs_version aliases=$docs_aliases"
 
       - name: Configure git for mike
@@ -95,7 +117,7 @@ jobs:
         env:
           DOCS_VERSION: ${{ steps.docs.outputs.version }}
           DOCS_ALIASES: ${{ steps.docs.outputs.aliases }}
-        run: mike deploy -u --push $DOCS_VERSION $DOCS_ALIASES
+        run: mike deploy -u --push "$DOCS_VERSION" $DOCS_ALIASES
 
       - name: Set default version
         if: (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch') && steps.docs.outputs.aliases != ''

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,3 +138,5 @@ jobs:
         with:
           generate_release_notes: true
           tag_name: ${{ github.ref_name }}
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ !contains(github.ref_name, '-') }}

--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,9 @@ docs/sample
 docs/changelog.md
 docs/markdown.md
 
+# Python
+__pycache__/
+
 # Graphify
 graphify-out/cost.json
 graphify-out/.graphify_python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   filter row, both client-side over already-loaded data. (`devview-networkmock`)
 - A [migration guide](docs/guides/migrating-to-openapi.md) and a `scripts/mocks_json_to_openapi.py`
   conversion script for integrators upgrading from a pre-0.2.0 `mocks.json` config.
+- `devview-consolelogger` module: displays the app's native console output (logcat on
+  Android, a stdout/stderr redirect on iOS) inside the DevView overlay, with per-level
+  filter chips, a text filter, and auto-follow. Capture works on an untethered device
+  (no debugger required) on both platforms; an optional `DevViewLogWriter` routes
+  Kermit-based logging into the same view, closing the one remaining gap
+  (`NSLog`/`os_log` on iOS with no debugger attached). Log-level colors are configurable
+  via a `LocalLogColorScheme` CompositionLocal. (`devview-consolelogger`)
 
 ### Changed
 - **Breaking:** `devview-networkmock-core` now parses OpenAPI 3.x documents (JSON, and YAML
@@ -49,13 +56,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   body on app start. Response variants are now only loaded when an operation's detail screen
   actually opens (`NetworkMockEndpointUiState.Content.responses`). (`devview-networkmock-core`,
   `devview-networkmock`)
-- `devview-consolelogger` module: displays the app's native console output (logcat on
-  Android, a stdout/stderr redirect on iOS) inside the DevView overlay, with per-level
-  filter chips, a text filter, and auto-follow. Capture works on an untethered device
-  (no debugger required) on both platforms; an optional `DevViewLogWriter` routes
-  Kermit-based logging into the same view, closing the one remaining gap
-  (`NSLog`/`os_log` on iOS with no debugger attached). Log-level colors are configurable
-  via a `LocalLogColorScheme` CompositionLocal. (`devview-consolelogger`)
 
 ## [0.1.5] - 2026-09-08
 
@@ -165,10 +165,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added and expanded unit test coverage for all primary `devview-*` modules.
 - Added Konsist architecture enforcement tests and Kover coverage reporting across the module set.
 
-[Unreleased]: https://github.com/worldline/DevView/compare/v0.1.5...HEAD
-[0.1.5]: https://github.com/worldline/DevView/compare/v0.1.4...v0.1.5
-[0.1.4]: https://github.com/worldline/DevView/compare/v0.1.3...v0.1.4
-[0.1.3]: https://github.com/worldline/DevView/compare/v0.1.2...v0.1.3
-[0.1.2]: https://github.com/worldline/DevView/compare/v0.1.1...v0.1.2
-[0.1.1]: https://github.com/worldline/DevView/compare/v0.1.0...v0.1.1
+[Unreleased]: https://github.com/worldline/DevView/compare/0.1.5...HEAD
+[0.1.5]: https://github.com/worldline/DevView/compare/0.1.4...0.1.5
+[0.1.4]: https://github.com/worldline/DevView/compare/0.1.3...0.1.4
+[0.1.3]: https://github.com/worldline/DevView/compare/0.1.2...0.1.3
+[0.1.2]: https://github.com/worldline/DevView/compare/0.1.1...0.1.2
+[0.1.1]: https://github.com/worldline/DevView/compare/v0.1.0...0.1.1
 [0.1.0]: https://github.com/worldline/DevView/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ On Windows, use `.\gradlew.bat` instead of `./gradlew`. Always append `-Pandroid
 
 **Docs (local preview):**
 ```shell
-pip install zensical==0.0.50
+pip install zensical==0.0.60
 zensical serve
 ```
 
@@ -128,7 +128,7 @@ Individual commits use **gitmoji** format: `:emoji: message` (e.g. `:fire: Remov
 
 ## Publishing
 
-Library group: `com.worldline.devview`. Version and Sonatype config are in `gradle.properties`. Publishing is handled by the `publish.yml` GitHub Actions workflow and `scripts/release.sh`.
+Library group: `com.worldline.devview`. Version and Sonatype config are in `gradle.properties`. Publishing is handled by the `publish.yml` GitHub Actions workflow and `scripts/release.py`.
 
 ## Changelog
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,8 @@
 
 **Added**
 
-- `devview-timecapsule` module: records the state history of the currently visible screen
+- `devview-timecapsule` module: records the state history of the currently visible screen via `TimeCapsuleEffect`/`TimeCapsuleOwner`, and lets a developer restore any earlier state back into that screen from the DevView overlay. History resets automatically when the screen leaves composition.
+
 ---
 
 ## What is DevView?

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,0 +1,2 @@
+zensical==0.0.60
+git+https://github.com/squidfunk/mike.git@2d4ad799442f4592db8ad53b179bfb33db8c69ac

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -1,16 +1,20 @@
 #!/bin/sh
 
+set -eu
+
 ./gradlew \
     :internal:dokka:dokkaGenerate
 
 rm -rf docs/api/
 cp -r internal/dokka/build/dokka/html/ docs/api/
 
-cp CHANGELOG.md docs/changelog.md
+# CHANGELOG.md links are repo-root relative (e.g. "docs/guides/foo.md"); once the file
+# lives inside docs/ that resolves to docs/docs/guides/foo.md, so strip the docs/ prefix.
+sed 's#](docs/#](#g' CHANGELOG.md > docs/changelog.md
 
 DEVVIEW_VERSION=${DEVVIEW_VERSION:-$(grep "^VERSION_NAME=" gradle.properties | cut -d'=' -f2 | sed 's/-SNAPSHOT//')}
 find docs -name "*.md" -exec sed -i "s/DEVVIEW_VERSION/$DEVVIEW_VERSION/g" {} \;
 
 if [ "$1" != "--prep-only" ]; then
-    zensical $@ --clean
+    zensical "$@" --clean
 fi

--- a/scripts/delete_old_version_docs.sh
+++ b/scripts/delete_old_version_docs.sh
@@ -1,24 +1,54 @@
 #!/bin/bash
 
-versions=($(mike list | tr ' ' '\n'))
+set -eu
+
+# Parse mike list output. Format: "version [alias1, alias2]  title"
+# We only care about version names (first column) and aliases.
+# Aliases like 'latest' and 'dev' must never be deleted.
+
+latest_alias_version=""
+dev_alias_version=""
+bare_versions=()
+
+while IFS= read -r line; do
+  version=$(echo "$line" | awk '{print $1}')
+  version_aliases=$(echo "$line" | grep -o '\[.*\]' | tr -d '[]' | tr ',' '\n' | xargs)
+
+  bare_versions+=("$version")
+
+  if echo "$version_aliases" | grep -qw "latest"; then
+    latest_alias_version="$version"
+  fi
+  if echo "$version_aliases" | grep -qw "dev"; then
+    dev_alias_version="$version"
+  fi
+done < <(mike list)
 
 declare -A major_latest
 
-# Find latest per X.Y
-for v in "${versions[@]}"; do
+for v in "${bare_versions[@]}"; do
   major="${v%.*}"
   if [[ -z "${major_latest[$major]}" ]]; then
     major_latest[$major]="$v"
   else
-    latest="${major_latest[$major]}"
-    # Use version sort (-V) to compare
-    greater=$(printf "%s\n%s\n" "$latest" "$v" | sort -V | tail -n1)
+    prev="${major_latest[$major]}"
+    greater=$(printf "%s\n%s\n" "$prev" "$v" | sort -V | tail -n1)
     major_latest[$major]="$greater"
   fi
 done
 
 to_delete=()
-for v in "${versions[@]}"; do
+for v in "${bare_versions[@]}"; do
+  # Never delete the version holding the 'latest' or 'dev' alias
+  if [[ "$v" == "$latest_alias_version" ]]; then
+    echo "Keeping $v (holds 'latest' alias)"
+    continue
+  fi
+  if [[ "$v" == "$dev_alias_version" ]]; then
+    echo "Keeping $v (holds 'dev' alias)"
+    continue
+  fi
+
   major="${v%.*}"
   if [[ "$v" != "${major_latest[$major]}" ]]; then
     to_delete+=("$v")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 
+import os
 import sys
 import re
 import shutil
 import subprocess
 from pathlib import Path
 from datetime import date
+
+GRADLEW = "gradlew.bat" if os.name == "nt" else "./gradlew"
 
 
 def run(cmd: list[str], check: bool = True) -> None:
@@ -14,16 +17,16 @@ def run(cmd: list[str], check: bool = True) -> None:
 
 
 def get_property(key: str, file: Path) -> str:
-    for line in file.read_text().splitlines():
+    for line in file.read_text(encoding="utf-8").splitlines():
         if line.startswith(f"{key}="):
             return line.split("=", 1)[1].strip()
     raise ValueError(f"Property {key} not found in {file}")
 
 
 def set_property(key: str, value: str, file: Path) -> None:
-    content = file.read_text()
+    content = file.read_text(encoding="utf-8")
     content = re.sub(rf"^{re.escape(key)}=.*$", f"{key}={value}", content, flags=re.MULTILINE)
-    file.write_text(content)
+    file.write_text(content, encoding="utf-8", newline="\n")
 
 
 def find_published_api_files() -> list[Path]:
@@ -32,7 +35,7 @@ def find_published_api_files() -> list[Path]:
         module_dir = api_txt.parent.parent
         props_file = module_dir / "gradle.properties"
         if props_file.exists():
-            content = props_file.read_text()
+            content = props_file.read_text(encoding="utf-8")
             if re.search(r"^POM_ARTIFACT_ID=", content, re.MULTILINE):
                 api_files.append(api_txt)
                 print(f"  Found published module: {module_dir}")
@@ -41,14 +44,27 @@ def find_published_api_files() -> list[Path]:
     return sorted(api_files)
 
 
+def _unreleased_body_start(lines: list[str], unreleased_index: int) -> int:
+    """Index of the first non-blank line under '## [Unreleased]', or len(lines) if none."""
+    body_index = unreleased_index + 1
+    while body_index < len(lines) and not lines[body_index].strip():
+        body_index += 1
+    return body_index
+
+
 def extract_changelog_section(version: str, changelog: Path) -> str:
     content = changelog.read_text(encoding="utf-8")
     start = content.find(f"## [{version}]")
     if start == -1:
         return ""
+
     next_section = content.find("\n## [", start + 1)
-    section = content[start:next_section].strip() if next_section != -1 else content[start:].strip()
-    # Drop the "## [version] - date" header line
+    link_match = re.compile(r"^\[[^\]\n]+\]: ", re.MULTILINE).search(content, start + 1)
+    stops = [i for i in (next_section, link_match.start() if link_match else -1) if i != -1]
+    end = min(stops) if stops else -1
+    section = content[start:end].strip() if end != -1 else content[start:].strip()
+
+    # Drop the release header line so docs/index.md can render the section body only.
     lines = section.splitlines()[1:]
     return "\n".join(lines).strip()
 
@@ -57,59 +73,136 @@ def update_whats_new(version: str, changelog_section: str, index: Path) -> None:
     content = index.read_text(encoding="utf-8")
     start = content.find("## What's New\n")
     if start == -1:
-        return
+        raise ValueError(f"{index} missing '## What's New' anchor")
+
     end = content.find("\n---\n", start)
     if end == -1:
-        return
-    # Convert ### Added/Fixed/Changed sub-headers into bullet groups
-    lines = []
+        raise ValueError(f"{index} missing '---' terminator after What's New")
+
+    # Convert Keep a Changelog sub-sections into a compact docs home summary. Bullets are
+    # hard-wrapped in CHANGELOG.md, so continuation lines get folded back into the bullet
+    # they belong to.
+    lines: list[str] = []
     for line in changelog_section.splitlines():
+        line = re.sub(r"\]\(docs/", "](", line)  # CHANGELOG.md links are repo-root relative
         if line.startswith("### "):
             lines.append(f"\n**{line[4:]}**\n")
         elif line.startswith("- "):
             lines.append(line)
+        elif line.strip() and lines and lines[-1].startswith("- "):
+            lines[-1] += " " + line.strip()
+
     new_section = f"## What's New\n\n### v{version}\n\n" + "\n".join(lines).strip()
-    content = content[:start] + new_section + content[end:]
-    index.write_text(content, encoding="utf-8")
+    # A blank line must precede the "---" terminator, or Markdown reads the preceding
+    # paragraph/list-item text as a Setext heading underline instead of a section break.
+    content = content[:start] + new_section + "\n" + content[end:]
+    index.write_text(content, encoding="utf-8", newline="\n")
 
 
 def update_changelog(version: str, changelog: Path) -> None:
-    content = changelog.read_text()
+    content = changelog.read_text(encoding="utf-8")
     today = date.today().strftime("%Y-%m-%d")
+    ends_with_newline = content.endswith("\n")
 
     if "## [Unreleased]" not in content:
         raise ValueError("CHANGELOG.md missing '## [Unreleased]' section")
+    if "[Unreleased]:" not in content:
+        raise ValueError("CHANGELOG.md missing [Unreleased] reference link")
 
-    # Insert new release section below [Unreleased]
-    new_content = content.replace(
-        "## [Unreleased]",
-        f"## [Unreleased]\n\n## [{version}] - {today}",
-        1,
-    )
+    release_header = f"## [{version}] - {today}"
 
-    # Update the [Unreleased] comparison link and insert a new version link
+    lines = content.splitlines()
+    try:
+        unreleased_index = lines.index("## [Unreleased]")
+    except ValueError as exc:
+        raise ValueError("CHANGELOG.md malformed") from exc
+
+    body_index = _unreleased_body_start(lines, unreleased_index)
+    rebuilt_lines = lines[: unreleased_index + 1] + ["", release_header, ""] + lines[body_index:]
+    content = "\n".join(rebuilt_lines)
+    if ends_with_newline:
+        content += "\n"
+
+    # Pull the current version from the existing [Unreleased] comparison link and rewrite
+    # the bottom reference block so the new release sits between the previous tag and HEAD.
+    # Tags in this repo are bare (0.1.5, not v0.1.5) -- `v?` tolerates the one legacy v0.1.0 link.
     link_re = re.compile(
-        r"^\[Unreleased\]: (https://github\.com/([^/]+/[^/]+))/compare/v(.+?)\.\.\.HEAD$",
+        r"^\[Unreleased\]: (https://github\.com/[^/]+/[^/]+)/compare/v?(.+?)\.\.\.HEAD$",
         re.MULTILINE,
     )
-    m = link_re.search(new_content)
-    if m:
-        base_url = m.group(1)
-        prev_version = m.group(3)
-        new_content = link_re.sub(
-            f"[Unreleased]: {base_url}/compare/v{version}...HEAD\n"
-            f"[{version}]: {base_url}/compare/v{prev_version}...v{version}",
-            new_content,
-        )
+    match = link_re.search(content)
+    if not match:
+        raise ValueError("CHANGELOG.md missing compare link for [Unreleased]")
 
-    changelog.write_text(new_content)
+    base_url = match.group(1)
+    prev_version = match.group(2)
+
+    rewritten_links = link_re.sub(
+        f"[Unreleased]: {base_url}/compare/{version}...HEAD\n"
+        f"[{version}]: {base_url}/compare/{prev_version}...{version}",
+        content,
+        count=1,
+    )
+
+    changelog.write_text(rewritten_links, encoding="utf-8", newline="\n")
+
+
+def preflight(new_version: str, changelog: Path) -> None:
+    """Everything checked here must pass before Step 1 mutates anything -- pushing the tag
+    in Step 6 fires publish.yml and is effectively irreversible."""
+    branch = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    if branch != "main":
+        print(f"Error: Must release from 'main', currently on '{branch}'")
+        sys.exit(1)
+
+    status = subprocess.run(
+        ["git", "status", "--porcelain"], capture_output=True, text=True, check=True,
+    ).stdout
+    if status.strip():
+        print("Error: Working tree has uncommitted or staged changes")
+        sys.exit(1)
+
+    run(["git", "fetch", "origin", "main", "--tags"])
+    local_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    remote_head = subprocess.run(
+        ["git", "rev-parse", "origin/main"], capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    if local_head != remote_head:
+        print("Error: Local 'main' is not up to date with 'origin/main'")
+        sys.exit(1)
+
+    tag_exists = subprocess.run(
+        ["git", "rev-parse", "-q", "--verify", f"refs/tags/{new_version}"], capture_output=True,
+    ).returncode == 0
+    if tag_exists:
+        print(f"Error: Tag {new_version} already exists")
+        sys.exit(1)
+
+    content = changelog.read_text(encoding="utf-8")
+    if "## [Unreleased]" not in content:
+        print("Error: CHANGELOG.md missing '## [Unreleased]' section")
+        sys.exit(1)
+    if "[Unreleased]:" not in content:
+        print("Error: CHANGELOG.md missing [Unreleased] reference link")
+        sys.exit(1)
+
+    lines = content.splitlines()
+    unreleased_index = lines.index("## [Unreleased]")
+    body_index = _unreleased_body_start(lines, unreleased_index)
+    if body_index >= len(lines) or lines[body_index].startswith(("## [", "[")):
+        print("Error: '## [Unreleased]' section is empty -- nothing to release")
+        sys.exit(1)
 
 
 def main():
     if len(sys.argv) < 2:
         print("Usage: release.py <release-version> [next-snapshot-version]")
-        print("  e.g. python3 release.py 0.2.0")
-        print("  e.g. python3 release.py 0.2.0 0.3.0-SNAPSHOT")
+        print("  e.g. python3 release.py 2.0.0")
+        print("  e.g. python3 release.py 2.0.0 2.1.0-SNAPSHOT")
         sys.exit(1)
 
     new_version = sys.argv[1]
@@ -128,10 +221,18 @@ def main():
 
     if len(sys.argv) >= 3:
         next_snapshot = sys.argv[2]
+    elif "-" in new_version:
+        # Pre-release (e.g. 0.3.0-alpha01): stay on the same base version so the next
+        # alpha/beta/final can still be cut from the same slot.
+        next_snapshot = f"{new_version.split('-', 1)[0]}-SNAPSHOT"
     else:
-        base = new_version.split("-")[0]
-        major, minor, patch = base.split(".")
-        next_snapshot = f"{major}.{minor}.{int(patch) + 1}-SNAPSHOT"
+        parts = new_version.split(".")
+        try:
+            major, minor, patch = parts
+            next_snapshot = f"{major}.{minor}.{int(patch) + 1}-SNAPSHOT"
+        except ValueError:
+            print(f"Error: Cannot infer next snapshot from '{new_version}'; pass it explicitly.")
+            sys.exit(1)
 
     print("=" * 50)
     print(f"  Releasing:     {new_version}")
@@ -139,50 +240,49 @@ def main():
     print(f"  Next snapshot: {next_snapshot}")
     print("=" * 50)
 
-    # Step 1: Bump version
+    print("\nPreflight checks...")
+    preflight(new_version, changelog)
+
     print("\nStep 1: Bumping version in gradle.properties...")
     set_property("VERSION_NAME", new_version, gradle_props)
 
-    # Step 2: Snapshot API files
-    print("\nStep 2: Copying api.txt snapshots for published modules...")
+    print("\nStep 2: Regenerating api.txt...")
+    run([GRADLEW, "metalavaGenerateSignature", "-Pandroidx.baselineprofile.skipgeneration"])
+
+    print("\nStep 3: Copying api.txt snapshots for published modules...")
     api_files = find_published_api_files()
+
     if not api_files:
         print("  Warning: No published modules with api.txt found")
+
     for api_txt in api_files:
         version_txt = api_txt.parent / f"{new_version}.txt"
         shutil.copy2(api_txt, version_txt)
         print(f"  Copied {api_txt} -> {version_txt}")
 
-    # Step 3: Update changelog
-    print("\nStep 3: Updating CHANGELOG.md...")
+    print("\nStep 4: Updating CHANGELOG.md and docs/index.md...")
     update_changelog(new_version, changelog)
 
-    # Step 3b: Sync docs changelog and update What's New
-    print("\nStep 3b: Updating docs/changelog.md and docs/index.md...")
-    docs_changelog = Path("docs/changelog.md")
     docs_index = Path("docs/index.md")
-    shutil.copy2(changelog, docs_changelog)
     section = extract_changelog_section(new_version, changelog)
     if section:
         update_whats_new(new_version, section, docs_index)
     else:
         print("  Warning: Could not find changelog section for this version")
 
-    # Step 4: Commit and tag
-    print("\nStep 4: Committing and tagging...")
+    print("\nStep 5: Committing and tagging...")
     run(["git", "add", str(gradle_props), str(changelog), str(docs_index)])
     for api_txt in api_files:
         version_txt = api_txt.parent / f"{new_version}.txt"
         run(["git", "add", str(version_txt)])
+
     run(["git", "commit", "-m", f"Prepare for release {new_version}"])
     run(["git", "tag", new_version])
 
-    # Step 5: Push tag — triggers publish.yml CI workflow
-    print("\nStep 5: Pushing tag...")
-    run(["git", "push", "origin", new_version])
+    print("\nStep 6: Pushing release commit and tag...")
+    run(["git", "push", "--atomic", "origin", "HEAD:refs/heads/main", new_version])
 
-    # Step 6: Next snapshot
-    print(f"\nStep 6: Setting next snapshot version ({next_snapshot})...")
+    print(f"\nStep 7: Setting next snapshot version ({next_snapshot})...")
     set_property("VERSION_NAME", next_snapshot, gradle_props)
     run(["git", "add", str(gradle_props)])
     run(["git", "commit", "-m", "Prepare next development version"])


### PR DESCRIPTION
## Summary
- `release.py` no longer aborts mid-release on the gitignored `docs/changelog.md`, uses bare (non-`v`-prefixed) compare links matching this repo's actual tags, adds a preflight gate (clean tree, on `main`, up to date, tag not already taken, `[Unreleased]` non-empty) before anything mutates, and fixes the What's New generator: wrapped CHANGELOG bullets were being truncated, `docs/`-relative links broke once copied into `docs/index.md`, and a missing blank line before `---` made Markdown misread a bullet as a heading — already visible on the live v0.1.5 docs entry.
- `release.py` step 2 no longer duplicates the Maven Central publish that `publish.yml` already does on tag push; it now only regenerates `api.txt` via metalava. Added Windows (`gradlew.bat`) support and pre-release-aware snapshot bumping (`0.3.0-alpha01` → `0.3.0-SNAPSHOT`, not `0.3.1-SNAPSHOT`).
- `build_docs.sh` gained `set -eu` (a failed Dokka build used to silently exit 0) and now strips `docs/`-relative links when copying `CHANGELOG.md`, fixing broken-link warnings from `zensical build`/`serve`.
- `delete_old_version_docs.sh` adopted haze's alias-safe `mike list` parsing — the old version could accidentally delete whichever docs version held the `latest` or `dev` alias.
- Pinned `zensical` (0.0.60) and the zensical-flavored `mike` fork to a specific commit via a new `pip-requirements.txt`, instead of installing `mike` from an unpinned `git+https` URL.
- `publish.yml` / `publish-docs.yml` validate `workflow_dispatch` inputs and flag pre-release tags (e.g. `1.0.0-beta01`) as GitHub prereleases without stealing the `latest` docs alias.
- `CHANGELOG.md` / `docs/index.md`: moved the `devview-consolelogger` bullet to `### Added` (it's a new module, not a change), fixed the bare compare links, and regenerated the truncated v0.1.5 What's New entry.

## Test plan
- [x] Dry-ran the full `release.py` pipeline (`update_changelog` → `extract_changelog_section` → `update_whats_new`) against copies of the real `CHANGELOG.md`/`docs/index.md`; verified every emitted compare link resolves via the GitHub API and no bullet is truncated.
- [x] Verified `preflight()` aborts before touching `gradle.properties` on a dirty tree, wrong branch, existing tag, and empty `[Unreleased]`.
- [x] Rebuilt the docs site locally with `zensical build --clean`; confirmed the What's New section renders as a proper `<ul>` (not a stray `<h2>`) and the build finishes with "No issues found" (previously 2 broken-link warnings).
- [x] `bash -n` on both shell scripts, `python -m py_compile` on `release.py`, YAML-parsed both modified workflow files.
- [ ] End-to-end dry run of an actual `release.py <version>` invocation against a disposable fork/tag (not done here — requires push/tag/publish side effects).