### PR TITLE
feat: redesign TimeCapsule row as a connected timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Kermit-based logging into the same view, closing the one remaining gap
   (`NSLog`/`os_log` on iOS with no debugger attached). Log-level colors are configurable
   via a `LocalLogColorScheme` CompositionLocal. (`devview-consolelogger`)
+- TimeCapsule rows now show a per-state change summary (e.g. `count 3 → 4`) derived from a
+  `key=value`-shaped label, expandable to reveal the full label with changed values
+  highlighted, plus a wall-clock timestamp alongside the existing delta pill. The screen now
+  shows a header naming the recorded owner. (`devview-timecapsule`)
 
 ### Changed
 - **Breaking:** `devview-networkmock-core` now parses OpenAPI 3.x documents (JSON, and YAML
@@ -56,6 +60,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   body on app start. Response variants are now only loaded when an operation's detail screen
   actually opens (`NetworkMockEndpointUiState.Content.responses`). (`devview-networkmock-core`,
   `devview-networkmock`)
+- `TimeCapsuleEffect` gains a `subtitle` parameter, inserted between `label` and `maxEntries`.
+  Callers passing `maxEntries` positionally must switch to a named argument.
+  (`devview-timecapsule`)
 
 ## [0.1.5] - 2026-09-08
 

--- a/devview-timecapsule/CLAUDE.md
+++ b/devview-timecapsule/CLAUDE.md
@@ -15,7 +15,7 @@ disk — the history is in-memory only, for the lifetime of the recording compos
 | Symbol | Kind | Description |
 |---|---|---|
 | `TimeCapsuleOwner<S>` | interface | Contract implemented by a screen's state holder: `state: StateFlow<S>` and `fun restoreState(state: S)` |
-| `TimeCapsuleEffect(owner, label, maxEntries)` | `@Composable` | Records `owner.state` for as long as it stays in composition; registers/unregisters with `TimeCapsule` via `DisposableEffect` |
+| `TimeCapsuleEffect(owner, label, subtitle, maxEntries)` | `@Composable` | Records `owner.state` for as long as it stays in composition; registers/unregisters with `TimeCapsule` via `DisposableEffect`. `subtitle` names the recorded screen in the Time Capsule header, defaulting to `owner`'s class name |
 | `TimeCapsule` | `object : Module` | Module entry point; registered with no arguments, like `FeatureFlip` |
 | `TimeCapsule.DEFAULT_MAX_ENTRIES` | `const Int` | Default retention (50) when `TimeCapsuleEffect` doesn't specify `maxEntries` |
 | `TimeCapsuleDestination.Main` | `@Serializable data object` | Only navigation destination; title "Time Capsule" |
@@ -27,8 +27,8 @@ all screen recording and retention logic lives there, but integrators only ever 
 ## Internal Architecture
 
 ```
-TimeCapsuleEffect(owner, label, maxEntries)
-    ├─ remember { ScreenCapsule(owner, label, maxEntries) }
+TimeCapsuleEffect(owner, label, subtitle, maxEntries)
+    ├─ remember { ScreenCapsule(owner, label, maxEntries, subtitleOverride = subtitle) }
     ├─ DisposableEffect: TimeCapsule.register(capsule) → onDispose { TimeCapsule.unregister(capsule) }
     └─ LaunchedEffect: owner.state.collect(capsule::record)
 
@@ -40,6 +40,7 @@ TimeCapsule (object : Module)
 
 ScreenCapsule<S>
     ├─ recordedEntries: SnapshotStateList<Recorded<S>>
+    ├─ subtitle: String? = subtitleOverride ?: owner::class.simpleName
     ├─ record(state): appends, drops oldest at maxEntries
     ├─ restore(id): owner.restoreState(entry.state) — no cast, entry is typed S
     └─ clear()
@@ -70,9 +71,24 @@ registry is a list instead: the outgoing capsule is removed from wherever it sit
   registry is read directly from the object inside `TimeCapsuleScreen`. There's exactly
   one consumer (the module's own screen) and no host-app use case for reading the registry
   elsewhere, so the extra indirection isn't justified here.
-- **Row delta, not wall-clock time.** `TimeCapsuleRow` shows the time elapsed since the
-  previous entry (`+120ms`), not an absolute timestamp — more useful for a state timeline
-  and avoids a date-formatting dependency.
+- **Row shows both a delta and a wall-clock timestamp.** `TimeCapsuleRow` shows the time
+  elapsed since the previous entry as a pill (`+120ms`, or `initial` for the oldest entry)
+  and the wall-clock time (`HH:mm:ss`, via `kotlinx.datetime` — this module's only consumer
+  of that dependency). They're rendered as visually separate elements (timestamp left, pill
+  right) rather than joined with `·`, which read ambiguously as fractional seconds
+  (`13:12:07 · +120ms` looked like `13:12:07.120`).
+- **The row's headline is a change summary, not the raw label.** `StateDiff.kt` parses a
+  `key=value`-shaped label (what `toString()` produces on a data class) and diffs it against
+  the previous entry's label, so the row reads `count 3 → 4` instead of the full
+  `CounterState(count=4, ...)`. A label with no parseable `key=value` pairs falls back to
+  showing itself verbatim, unchanged from the original behavior. Expanding a row reveals the
+  full label below a divider, with the changed values highlighted — this is also the only way
+  to read a label that's been truncated at two lines.
+- **Header subtitle defaults to the owner's class name.** `TimeCapsuleEffect`'s `subtitle`
+  parameter is shown as "Recording {subtitle}" above the timeline, so a tester can confirm
+  which screen they're looking at. Defaulting to `owner::class.simpleName` (rather than
+  `null`) means most integrators get this for free; `simpleName` is `null` for an anonymous
+  class, which integrators must override explicitly in that case.
 
 ## Platform-Specific Code
 

--- a/devview-timecapsule/api/api.txt
+++ b/devview-timecapsule/api/api.txt
@@ -24,7 +24,7 @@ package com.worldline.devview.timecapsule {
   }
 
   public final class TimeCapsuleEffectKt {
-    method @KotlinOnly @androidx.compose.runtime.Composable public static <S> void TimeCapsuleEffect(com.worldline.devview.timecapsule.TimeCapsuleOwner<S> owner, optional kotlin.jvm.functions.Function1<S,java.lang.String> label, optional int maxEntries);
+    method @KotlinOnly @androidx.compose.runtime.Composable public static <S> void TimeCapsuleEffect(com.worldline.devview.timecapsule.TimeCapsuleOwner<S> owner, optional kotlin.jvm.functions.Function1<S,java.lang.String> label, optional String? subtitle, optional int maxEntries);
   }
 
   public interface TimeCapsuleOwner<S> {

--- a/devview-timecapsule/build.gradle.kts
+++ b/devview-timecapsule/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
                 api(projects.devview)
                 implementation(libs.kotlinx.coroutines.core)
                 implementation(libs.kotlinx.collections.immutable)
+                implementation(libs.kotlinx.datetime)
             }
         }
     }

--- a/devview-timecapsule/src/commonMain/kotlin/com/worldline/devview/timecapsule/FieldChange.kt
+++ b/devview-timecapsule/src/commonMain/kotlin/com/worldline/devview/timecapsule/FieldChange.kt
@@ -1,0 +1,108 @@
+package com.worldline.devview.timecapsule
+
+/**
+ * One `key=value` field that differs between two labels, with [newValueRange] pointing at
+ * where [new] sits in the *current* label so callers can highlight it in place.
+ */
+internal data class FieldChange(
+    val key: String,
+    val old: String,
+    val new: String,
+    val newValueRange: IntRange
+)
+
+// ponytail: 3 fits two lines of bodyMedium for typical short values. It's a display cap,
+// not a diff cap — expanding always lists every change. Tune if it reads badly.
+private const val COLLAPSED_CHANGE_LIMIT = 3
+
+/**
+ * Diffs two `toString()`-shaped labels field by field, e.g. `CounterState(count=3, name=foo)`
+ * vs `CounterState(count=4, name=foo)` → `[FieldChange(key="count", old="3", new="4", ...)]`.
+ *
+ * Only keys present on both sides are compared; a label with no parseable `key=value` pairs
+ * (or `previous == null`) yields an empty list — callers fall back to showing the label as-is.
+ */
+internal fun diffLabels(current: String, previous: String?): List<FieldChange> {
+    if (previous == null) return emptyList()
+
+    val currentFields = parseFields(label = current)
+    val previousFields = parseFields(label = previous).associateBy { it.key }
+    if (currentFields.isEmpty() || previousFields.isEmpty()) return emptyList()
+
+    return currentFields.mapNotNull { field ->
+        val old = previousFields[field.key] ?: return@mapNotNull null
+        if (old.value == field.value) return@mapNotNull null
+        FieldChange(
+            key = field.key,
+            old = old.value,
+            new = field.value,
+            newValueRange = field.valueRange
+        )
+    }
+}
+
+/**
+ * The changes to actually display: every change when [expanded], otherwise the first
+ * [COLLAPSED_CHANGE_LIMIT] — callers show `size - shownChanges(...).size` as a "+N more" suffix.
+ *
+ * Kept as plain string/list logic (no Compose types) so it stays unit-testable without a
+ * Compose runtime; the styled rendering lives in `TimeCapsuleRow.kt`.
+ */
+internal fun List<FieldChange>.shownChanges(expanded: Boolean): List<FieldChange> =
+    if (expanded) this else take(n = COLLAPSED_CHANGE_LIMIT)
+
+private data class ParsedField(val key: String, val value: String, val valueRange: IntRange)
+
+// Parses `key=value` pairs out of a `toString()`-shaped label, splitting on top-level commas
+// only (bracket/paren/brace depth tracked) so nested or list-shaped values — `items=[a, b]`,
+// `addr=Address(city=Paris)` — survive as a single field instead of being split apart.
+private fun parseFields(label: String): List<ParsedField> {
+    val openParen = label.indexOf(char = '(')
+    val closeParen = label.lastIndexOf(char = ')')
+    val contentStart: Int
+    val content: String
+    if (openParen != -1 && closeParen > openParen) {
+        contentStart = openParen + 1
+        content = label.substring(startIndex = contentStart, endIndex = closeParen)
+    } else {
+        contentStart = 0
+        content = label
+    }
+
+    val fields = mutableListOf<ParsedField>()
+    var depth = 0
+    var segmentStart = 0
+
+    fun addSegment(endIndex: Int) {
+        val segment = content.substring(startIndex = segmentStart, endIndex = endIndex)
+        val equalsIndex = segment.indexOf(char = '=')
+        if (equalsIndex == -1) return
+
+        val key = segment.substring(startIndex = 0, endIndex = equalsIndex).trim()
+        val rawValue = segment.substring(startIndex = equalsIndex + 1)
+        val value = rawValue.trim()
+        if (key.isEmpty() || value.isEmpty()) return
+
+        val valueOffsetInSegment = equalsIndex + 1 + (rawValue.length - rawValue.trimStart().length)
+        val valueStart = contentStart + segmentStart + valueOffsetInSegment
+        fields += ParsedField(
+            key = key,
+            value = value,
+            valueRange = valueStart until valueStart + value.length
+        )
+    }
+
+    for (index in content.indices) {
+        when (content[index]) {
+            '(', '[', '{' -> depth++
+            ')', ']', '}' -> depth--
+            ',' -> if (depth == 0) {
+                addSegment(endIndex = index)
+                segmentStart = index + 1
+            }
+        }
+    }
+    addSegment(endIndex = content.length)
+
+    return fields
+}

--- a/devview-timecapsule/src/commonMain/kotlin/com/worldline/devview/timecapsule/ScreenCapsule.kt
+++ b/devview-timecapsule/src/commonMain/kotlin/com/worldline/devview/timecapsule/ScreenCapsule.kt
@@ -21,12 +21,22 @@ internal data class Recorded<out S : Any>(
 internal class ScreenCapsule<S : Any>(
     private val owner: TimeCapsuleOwner<S>,
     private val label: (S) -> String,
-    private val maxEntries: Int
+    private val maxEntries: Int,
+    subtitleOverride: String? = null
 ) {
     private val recordedEntries = mutableStateListOf<Recorded<S>>()
     private var nextId = 0L
 
     val entries: List<Recorded<S>> get() = recordedEntries
+
+    /**
+     * Identifies which screen is recording, shown as a header above the timeline.
+     *
+     * ponytail: R8 would obfuscate this in a minified build. DevView is a debug-only overlay
+     * so that combination shouldn't arise; integrators who hit it pass `subtitleOverride`
+     * explicitly.
+     */
+    val subtitle: String? = subtitleOverride ?: owner::class.simpleName
 
     fun record(state: S) {
         if (recordedEntries.size == maxEntries) {

--- a/devview-timecapsule/src/commonMain/kotlin/com/worldline/devview/timecapsule/TimeCapsuleEffect.kt
+++ b/devview-timecapsule/src/commonMain/kotlin/com/worldline/devview/timecapsule/TimeCapsuleEffect.kt
@@ -28,6 +28,9 @@ import androidx.compose.runtime.remember
  * @param owner The screen's state holder, typically a `ViewModel`.
  * @param label Produces the one-line description shown for each recorded entry. Defaults to
  *   `state.toString()`.
+ * @param subtitle Identifies the recorded screen in the Time Capsule header (e.g. `"Recording
+ *   CounterViewModel"`). Defaults to `owner`'s class name, which is `null` for an anonymous
+ *   class — pass this explicitly in that case.
  * @param maxEntries Maximum number of retained entries; the oldest is dropped once reached.
  *
  * @see TimeCapsuleOwner
@@ -37,10 +40,16 @@ import androidx.compose.runtime.remember
 public fun <S : Any> TimeCapsuleEffect(
     owner: TimeCapsuleOwner<S>,
     label: (S) -> String = { it.toString() },
+    subtitle: String? = null,
     maxEntries: Int = TimeCapsule.DEFAULT_MAX_ENTRIES
 ) {
     val capsule = remember(key1 = owner) {
-        ScreenCapsule(owner = owner, label = label, maxEntries = maxEntries)
+        ScreenCapsule(
+            owner = owner,
+            label = label,
+            maxEntries = maxEntries,
+            subtitleOverride = subtitle
+        )
     }
 
     DisposableEffect(key1 = capsule) {

--- a/devview-timecapsule/src/commonMain/kotlin/com/worldline/devview/timecapsule/TimeCapsuleScreen.kt
+++ b/devview-timecapsule/src/commonMain/kotlin/com/worldline/devview/timecapsule/TimeCapsuleScreen.kt
@@ -5,16 +5,22 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.History
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -37,54 +43,82 @@ import com.worldline.devview.timecapsule.components.TimeCapsuleRow
 public fun TimeCapsuleScreen(modifier: Modifier = Modifier, bottomPadding: Dp = 0.dp) {
     val capsule = TimeCapsule.current
     val entries = capsule?.entries.orEmpty().asReversed()
+    var expandedIds by remember { mutableStateOf(value = emptySet<Long>()) }
 
-    if (entries.isEmpty()) {
-        Box(
-            modifier = modifier.fillMaxSize().padding(all = 32.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(space = 8.dp)
+    Column(modifier = modifier.fillMaxSize()) {
+        capsule?.subtitle?.let { subtitle ->
+            Text(
+                text = "Recording $subtitle",
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            HorizontalDivider()
+        }
+
+        if (entries.isEmpty()) {
+            Box(
+                modifier = Modifier.weight(weight = 1f).fillMaxWidth().padding(all = 32.dp),
+                contentAlignment = Alignment.Center
             ) {
-                Icon(
-                    imageVector = Icons.Rounded.History,
-                    contentDescription = null,
-                    modifier = Modifier.size(size = 48.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                Text(
-                    text = if (capsule == null) {
-                        "No screen is recording. Add TimeCapsuleEffect(owner) to a screen."
-                    } else {
-                        "No states captured yet."
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(space = 8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.History,
+                        contentDescription = null,
+                        modifier = Modifier.size(size = 48.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text = if (capsule == null) {
+                            "No screen is recording. Add TimeCapsuleEffect(owner) to a screen."
+                        } else {
+                            "No states captured yet."
+                        },
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+            return@Column
+        }
+
+        LazyColumn(
+            modifier = Modifier.weight(weight = 1f).fillMaxWidth(),
+            contentPadding = PaddingValues(
+                start = 16.dp,
+                top = 16.dp,
+                end = 16.dp,
+                bottom = bottomPadding + 16.dp
+            )
+        ) {
+            itemsIndexed(items = entries, key = { _, entry -> entry.id }) { index, entry ->
+                val previous = entries.getOrNull(index = index + 1)
+                TimeCapsuleRow(
+                    entry = entry,
+                    previousLabel = previous?.label,
+                    deltaMillis = previous?.let { entry.atMillis - it.atMillis },
+                    isCurrent = index == 0,
+                    isLast = index == entries.lastIndex,
+                    expanded = entry.id in expandedIds,
+                    onExpandToggle = {
+                        expandedIds = if (entry.id in expandedIds) {
+                            expandedIds - entry.id
+                        } else {
+                            expandedIds + entry.id
+                        }
                     },
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    textAlign = TextAlign.Center
+                    onRestoreClick = { capsule?.restore(id = entry.id) },
+                    // Without this, an item's own expand/collapse resize snaps the items below it
+                    // straight to their new position instead of sliding — animateItem() is what
+                    // lets the rail (its height following this row's) resize in step with siblings
+                    // reflowing, rather than the two visibly disagreeing mid-animation.
+                    modifier = Modifier.animateItem()
                 )
             }
-        }
-        return
-    }
-
-    LazyColumn(
-        modifier = modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(space = 12.dp),
-        contentPadding = PaddingValues(
-            start = 16.dp,
-            top = 16.dp,
-            end = 16.dp,
-            bottom = bottomPadding + 16.dp
-        )
-    ) {
-        itemsIndexed(items = entries, key = { _, entry -> entry.id }) { index, entry ->
-            val previousAtMillis = entries.getOrNull(index = index + 1)?.atMillis
-            TimeCapsuleRow(
-                entry = entry,
-                deltaMillis = previousAtMillis?.let { entry.atMillis - it },
-                onRestoreClick = { capsule?.restore(id = entry.id) }
-            )
         }
     }
 }

--- a/devview-timecapsule/src/commonMain/kotlin/com/worldline/devview/timecapsule/components/TimeCapsuleRow.kt
+++ b/devview-timecapsule/src/commonMain/kotlin/com/worldline/devview/timecapsule/components/TimeCapsuleRow.kt
@@ -1,63 +1,358 @@
 package com.worldline.devview.timecapsule.components
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Card
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.KeyboardArrowUp
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
+import com.worldline.devview.timecapsule.FieldChange
 import com.worldline.devview.timecapsule.Recorded
+import com.worldline.devview.timecapsule.diffLabels
+import com.worldline.devview.timecapsule.shownChanges
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.DurationUnit
+import kotlin.time.Instant
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format
+import kotlinx.datetime.format.char
+import kotlinx.datetime.toLocalDateTime
+
+private val RailWidth = 24.dp
+private val CurrentNodeSize = 12.dp
+private val NodeSize = 8.dp
+private val NodeHaloSize = 22.dp
+private val CardShape = RoundedCornerShape(size = 12.dp)
 
 /**
  * Single entry in the [com.worldline.devview.timecapsule.TimeCapsuleScreen] timeline.
  *
+ * The first line is a change summary against [previousLabel] (e.g. `"count: 3 → 4"`), falling
+ * back to [Recorded.label] verbatim when it isn't `key=value`-shaped. Expanding a row reveals
+ * the full label below a divider, with changed values highlighted. A rail on the left threads
+ * the row into the surrounding timeline, marking [isCurrent] with a small halo.
+ *
+ * @param previousLabel Label of the entry recorded just before this one, or `null` for the
+ *   oldest entry.
  * @param deltaMillis Time elapsed since the previous entry, or `null` for the oldest entry.
+ * @param isCurrent Whether this is the most recently recorded entry.
+ * @param isLast Whether this is the oldest entry — the rail's connecting line stops here.
  */
 @Composable
 internal fun TimeCapsuleRow(
     entry: Recorded<*>,
+    previousLabel: String?,
     deltaMillis: Long?,
+    isCurrent: Boolean,
+    isLast: Boolean,
+    expanded: Boolean,
+    onExpandToggle: () -> Unit,
     onRestoreClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Card(modifier = modifier.fillMaxWidth()) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(all = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(space = 12.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(
-                modifier = Modifier.weight(weight = 1f),
-                verticalArrangement = Arrangement.spacedBy(space = 4.dp)
-            ) {
-                Text(
-                    text = entry.label,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = deltaMillis?.let { "+${formatDelta(millis = it)}" } ?: "Initial state",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+    val changes = remember(key1 = entry.label, key2 = previousLabel) {
+        diffLabels(current = entry.label, previous = previousLabel)
+    }
+    var summaryOverflows by remember { mutableStateOf(value = false) }
+    val isExpandable = changes.isNotEmpty() || summaryOverflows
+    val chevronRotation by animateFloatAsState(targetValue = if (expanded) 180f else 0f)
+
+    // A Row sized via IntrinsicSize.Min doesn't track AnimatedVisibility's per-frame animated
+    // height, and layering animateContentSize() on top just adds a second, independent animation
+    // that isn't guaranteed to stay in step with it — close, but visibly not quite synced.
+    // Measuring the content for real every frame and forcing the rail to that exact height has
+    // no separate clock to drift: the rail can't help but match, because it's the same number.
+    Layout(
+        modifier = modifier.fillMaxWidth().testTag(tag = "time_capsule_row_${entry.id}"),
+        content = {
+            TimelineRail(isCurrent = isCurrent, isLast = isLast)
+            RowContent(
+                entry = entry,
+                changes = changes,
+                deltaMillis = deltaMillis,
+                expanded = expanded,
+                isExpandable = isExpandable,
+                chevronRotation = chevronRotation,
+                onExpandToggle = onExpandToggle,
+                onRestoreClick = onRestoreClick,
+                onSummaryOverflowChange = { summaryOverflows = it }
+            )
+        }
+    ) { measurables, constraints ->
+        val (rail, content) = measurables
+        val contentWidth = (constraints.maxWidth - RailWidth.roundToPx()).coerceAtLeast(
+            minimumValue = 0
+        )
+        val contentPlaceable = content.measure(
+            constraints = constraints.copy(minWidth = contentWidth, maxWidth = contentWidth)
+        )
+        val railPlaceable = rail.measure(
+            constraints = Constraints.fixed(
+                width = RailWidth.roundToPx(),
+                height = contentPlaceable.height
+            )
+        )
+        layout(width = constraints.maxWidth, height = contentPlaceable.height) {
+            railPlaceable.placeRelative(x = 0, y = 0)
+            contentPlaceable.placeRelative(x = railPlaceable.width, y = 0)
+        }
+    }
+}
+
+@Composable
+private fun RowContent(
+    entry: Recorded<*>,
+    changes: List<FieldChange>,
+    deltaMillis: Long?,
+    expanded: Boolean,
+    isExpandable: Boolean,
+    chevronRotation: Float,
+    onExpandToggle: () -> Unit,
+    onRestoreClick: () -> Unit,
+    onSummaryOverflowChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .padding(start = 12.dp, top = 4.dp, bottom = 12.dp)
+            // Clipping before the background/clickable draw so the ripple (drawn as part of
+            // clickable's indication) is bounded to the same rounded shape as the card behind it,
+            // instead of the default rectangular ripple spilling past the rounded corners.
+            .clip(shape = CardShape)
+            .background(color = MaterialTheme.colorScheme.surfaceContainer)
+            .clickable(enabled = isExpandable, onClick = onExpandToggle)
+            .padding(all = 12.dp)
+    ) {
+        Text(
+            text = summaryText(
+                label = entry.label,
+                changes = changes,
+                expanded = expanded,
+                mutedColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                emphasisColor = MaterialTheme.colorScheme.primary
+            ),
+            maxLines = if (expanded) Int.MAX_VALUE else 2,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.bodyLarge,
+            // Guarded on `!expanded`: once expanded, layout no longer overflows (maxLines is
+            // unbounded), which would otherwise flip this back to false and hide the chevron.
+            onTextLayout = { layout ->
+                if (!expanded) {
+                    onSummaryOverflowChange(
+                        layout.hasVisualOverflow
+                    )
+                }
             }
-            OutlinedButton(onClick = onRestoreClick) {
-                Text(text = "Restore")
+        )
+
+        AnimatedVisibility(visible = expanded) {
+            // Top padding lives inside the animated content (not as Column spacing) so it
+            // shrinks away together with the divider and text as this collapses — an
+            // Arrangement.spacedBy gap on the parent stays fixed regardless of this child's
+            // animated height, leaving dead space until the child is removed outright.
+            Column(modifier = Modifier.padding(top = 10.dp)) {
+                HorizontalDivider()
+                Text(
+                    modifier = Modifier.padding(top = 10.dp),
+                    text = highlightedLabel(
+                        label = entry.label,
+                        changes = changes,
+                        highlightBackground = MaterialTheme.colorScheme.primaryContainer,
+                        highlightContent = MaterialTheme.colorScheme.onPrimaryContainer
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace
+                )
             }
         }
+
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(top = 10.dp),
+            horizontalArrangement = Arrangement.spacedBy(space = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = formatTimestamp(millis = entry.atMillis),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            DeltaPill(deltaMillis = deltaMillis)
+            if (isExpandable) {
+                IconButton(
+                    modifier = Modifier
+                        .size(size = 32.dp)
+                        .testTag(tag = "time_capsule_expand_${entry.id}"),
+                    onClick = onExpandToggle
+                ) {
+                    Icon(
+                        modifier = Modifier.graphicsLayer(rotationX = chevronRotation),
+                        imageVector = Icons.Rounded.KeyboardArrowUp,
+                        contentDescription = if (expanded) "Collapse" else "Expand"
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.weight(weight = 1f))
+            TextButton(onClick = onRestoreClick) {
+                Text(text = "Restore", fontWeight = FontWeight.SemiBold)
+            }
+        }
+    }
+}
+
+/** The node-and-line spine threading rows into a timeline; [isCurrent] gets a halo. */
+@Composable
+private fun TimelineRail(isCurrent: Boolean, isLast: Boolean, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.width(width = RailWidth).fillMaxHeight(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(modifier = Modifier.padding(top = 8.dp), contentAlignment = Alignment.Center) {
+            if (isCurrent) {
+                Box(
+                    modifier = Modifier
+                        .size(size = NodeHaloSize)
+                        .background(
+                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
+                            shape = CircleShape
+                        )
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .size(size = if (isCurrent) CurrentNodeSize else NodeSize)
+                    .background(
+                        color = if (isCurrent) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.outline
+                        },
+                        shape = CircleShape
+                    )
+            )
+        }
+        if (!isLast) {
+            Box(
+                modifier = Modifier
+                    .weight(weight = 1f)
+                    .width(width = 2.dp)
+                    .background(color = MaterialTheme.colorScheme.outlineVariant)
+            )
+        }
+    }
+}
+
+@Composable
+private fun DeltaPill(deltaMillis: Long?, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .background(
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                shape = MaterialTheme.shapes.extraSmall
+            ).padding(horizontal = 6.dp, vertical = 2.dp)
+    ) {
+        Text(
+            text = deltaMillis?.let { "+${formatDelta(millis = it)}" } ?: "initial",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+
+// Builds the collapsed/expanded headline: `key: old → new` per change, old struck through and
+// muted, new emphasized — falling back to `label` verbatim when there's nothing to diff.
+private fun summaryText(
+    label: String,
+    changes: List<FieldChange>,
+    expanded: Boolean,
+    mutedColor: Color,
+    emphasisColor: Color
+): AnnotatedString = buildAnnotatedString {
+    if (changes.isEmpty()) {
+        append(text = label)
+        return@buildAnnotatedString
+    }
+
+    val shown = changes.shownChanges(expanded = expanded)
+    shown.forEachIndexed { index, change ->
+        if (index > 0) append(text = ", ")
+        withStyle(style = SpanStyle(color = mutedColor)) {
+            append(text = "${change.key}: ")
+        }
+        withStyle(
+            style = SpanStyle(color = mutedColor, textDecoration = TextDecoration.LineThrough)
+        ) {
+            append(text = change.old)
+        }
+        withStyle(style = SpanStyle(color = mutedColor)) {
+            append(text = " → ")
+        }
+        withStyle(style = SpanStyle(color = emphasisColor, fontWeight = FontWeight.SemiBold)) {
+            append(text = change.new)
+        }
+    }
+
+    val remaining = changes.size - shown.size
+    if (remaining > 0) {
+        withStyle(style = SpanStyle(color = mutedColor)) {
+            append(text = "  +$remaining more")
+        }
+    }
+}
+
+private fun highlightedLabel(
+    label: String,
+    changes: List<FieldChange>,
+    highlightBackground: Color,
+    highlightContent: Color
+): AnnotatedString = buildAnnotatedString {
+    append(text = label)
+    changes.forEach { change ->
+        addStyle(
+            style = SpanStyle(background = highlightBackground, color = highlightContent),
+            start = change.newValueRange.first,
+            end = change.newValueRange.last + 1
+        )
     }
 }
 
@@ -69,3 +364,21 @@ private fun formatDelta(millis: Long): String {
         duration.toString(unit = DurationUnit.SECONDS, decimals = 1)
     }
 }
+
+// ponytail: third copy of this HH:mm:ss formatter (see AnalyticsLog.kt, ConsoleLog.kt).
+// Consolidating needs a new public symbol in devview + metalava/doc churn in 3 modules — more
+// expensive than the duplication. Extract if a fourth copy appears.
+private fun formatTimestamp(millis: Long): String = Instant
+    .fromEpochMilliseconds(
+        epochMilliseconds = millis
+    ).toLocalDateTime(timeZone = TimeZone.currentSystemDefault())
+    .time
+    .format(
+        format = LocalTime.Format {
+            hour()
+            char(value = ':')
+            minute()
+            char(value = ':')
+            second()
+        }
+    )

--- a/devview-timecapsule/src/commonTest/kotlin/com/worldline/devview/timecapsule/ScreenCapsuleTest.kt
+++ b/devview-timecapsule/src/commonTest/kotlin/com/worldline/devview/timecapsule/ScreenCapsuleTest.kt
@@ -78,6 +78,29 @@ internal class ScreenCapsuleTest {
         capsule.entries.shouldBeEmpty()
     }
 
+    @Test
+    fun `subtitle defaults to the owner's class name`() {
+        val capsule = ScreenCapsule(
+            owner = FakeOwner(initial = CounterState(count = 0)),
+            label = { it.count.toString() },
+            maxEntries = 10
+        )
+
+        capsule.subtitle shouldBe "FakeOwner"
+    }
+
+    @Test
+    fun `subtitle override wins over the owner's class name`() {
+        val capsule = ScreenCapsule(
+            owner = FakeOwner(initial = CounterState(count = 0)),
+            label = { it.count.toString() },
+            maxEntries = 10,
+            subtitleOverride = "Counter screen"
+        )
+
+        capsule.subtitle shouldBe "Counter screen"
+    }
+
     private data class CounterState(val count: Int)
 
     private class FakeOwner(initial: CounterState) : TimeCapsuleOwner<CounterState> {

--- a/devview-timecapsule/src/commonTest/kotlin/com/worldline/devview/timecapsule/StateDiffTest.kt
+++ b/devview-timecapsule/src/commonTest/kotlin/com/worldline/devview/timecapsule/StateDiffTest.kt
@@ -1,0 +1,108 @@
+package com.worldline.devview.timecapsule
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+internal class StateDiffTest {
+
+    @Test
+    fun `diffLabels finds a single changed field with correct range`() {
+        val current = "CounterState(count=4, name=foo)"
+        val previous = "CounterState(count=3, name=foo)"
+
+        val changes = diffLabels(current = current, previous = previous)
+
+        changes shouldHaveSize 1
+        val change = changes.single()
+        change.key shouldBe "count"
+        change.old shouldBe "3"
+        change.new shouldBe "4"
+        current.substring(range = change.newValueRange) shouldBe "4"
+    }
+
+    @Test
+    fun `diffLabels keeps list and nested parenthesis values intact`() {
+        val current = "ListState(items=[a, b, c], addr=Address(city=Paris, zip=75000), loading=false)"
+        val previous = "ListState(items=[a, b], addr=Address(city=Paris, zip=75000), loading=false)"
+
+        val changes = diffLabels(current = current, previous = previous)
+
+        changes shouldHaveSize 1
+        val change = changes.single()
+        change.key shouldBe "items"
+        change.old shouldBe "[a, b]"
+        change.new shouldBe "[a, b, c]"
+        current.substring(range = change.newValueRange) shouldBe "[a, b, c]"
+    }
+
+    @Test
+    fun `diffLabels parses spaced key equals value form`() {
+        val changes = diffLabels(current = "Count = 4", previous = "Count = 3")
+
+        changes shouldHaveSize 1
+        val change = changes.single()
+        change.key shouldBe "Count"
+        change.old shouldBe "3"
+        change.new shouldBe "4"
+    }
+
+    @Test
+    fun `diffLabels returns empty list when label has no key value pairs`() {
+        diffLabels(current = "Logged in", previous = "Logged out").shouldBeEmpty()
+    }
+
+    @Test
+    fun `diffLabels returns empty list when there is no previous label`() {
+        diffLabels(current = "CounterState(count=4)", previous = null).shouldBeEmpty()
+    }
+
+    @Test
+    fun `diffLabels returns empty list for identical labels`() {
+        val label = "CounterState(count=4, name=foo)"
+
+        diffLabels(current = label, previous = label).shouldBeEmpty()
+    }
+
+    @Test
+    fun `diffLabels ignores keys present on only one side`() {
+        val current = "CounterState(count=4, name=foo)"
+        val previous = "CounterState(count=3)"
+
+        val changes = diffLabels(current = current, previous = previous)
+
+        changes shouldHaveSize 1
+        changes.single().key shouldBe "count"
+    }
+
+    @Test
+    fun `shownChanges caps at the limit when collapsed`() {
+        val changes = fieldChanges(count = 7)
+
+        changes.shownChanges(expanded = false).map { it.key } shouldBe listOf("f1", "f2", "f3")
+    }
+
+    @Test
+    fun `shownChanges returns every change when expanded`() {
+        val changes = fieldChanges(count = 7)
+
+        changes.shownChanges(expanded = true) shouldBe changes
+    }
+
+    @Test
+    fun `shownChanges returns everything when the count is at or under the limit`() {
+        val changes = fieldChanges(count = 3)
+
+        changes.shownChanges(expanded = false) shouldBe changes
+    }
+
+    @Test
+    fun `shownChanges stays empty for an empty list`() {
+        emptyList<FieldChange>().shownChanges(expanded = false).shouldBeEmpty()
+    }
+
+    private fun fieldChanges(count: Int): List<FieldChange> = (1..count).map { index ->
+        FieldChange(key = "f$index", old = "$index", new = "${index + 1}", newValueRange = 0 until 1)
+    }
+}

--- a/docs/modules/timecapsule.md
+++ b/docs/modules/timecapsule.md
@@ -47,13 +47,22 @@ Call once per screen, inside the screen's top-level composable:
 public fun <S : Any> TimeCapsuleEffect(
     owner: TimeCapsuleOwner<S>,
     label: (S) -> String = { it.toString() },
+    subtitle: String? = null,
     maxEntries: Int = TimeCapsule.DEFAULT_MAX_ENTRIES
 )
 ```
 
 `label` produces the one-line description shown for each recorded entry — defaults to
-`state.toString()`. `maxEntries` bounds retention; the oldest entry is dropped once
-reached.
+`state.toString()`. When a label is shaped like `key=value, key=value` (what `toString()`
+produces on a data class), the timeline shows a change summary against the previous entry
+instead — e.g. `count 3 → 4` — and expanding a row reveals the full label with changed
+values highlighted. A label with no parseable `key=value` pairs is shown verbatim, exactly
+as before.
+
+`subtitle` names the recorded screen in the Time Capsule header ("Recording {subtitle}"),
+so a tester can confirm which screen they're looking at. Defaults to `owner`'s class name;
+pass this explicitly if `owner` is an anonymous class, where the class name is unavailable.
+`maxEntries` bounds retention; the oldest entry is dropped once reached.
 
 ### `TimeCapsule`
 
@@ -87,16 +96,19 @@ class CounterViewModel : ViewModel(), TimeCapsuleOwner<CounterState> {
 fun CounterScreen(viewModel: CounterViewModel) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
-    TimeCapsuleEffect(owner = viewModel, label = { "Count = ${it.count}" })
+    TimeCapsuleEffect(owner = viewModel)
 
     // ...screen content
 }
 ```
 
 With this wired up, incrementing the counter records a new entry on every change. Opening
-DevView → Time Capsule shows the history newest-first; tapping **Restore** on any entry
-calls `restoreState` with that entry's value, and the running screen reflects it
-immediately. Navigating away from `CounterScreen` and back starts a fresh, empty history.
+DevView → Time Capsule shows a "Recording CounterViewModel" header, then the history
+newest-first: `CounterState`'s default `toString()`-shaped label lets each row show a
+change summary (`count 3 → 4`) instead of the full state, expandable to see the rest.
+Tapping **Restore** on any entry calls `restoreState` with that entry's value, and the
+running screen reflects it immediately. Navigating away from `CounterScreen` and back
+starts a fresh, empty history.
 
 ## Sample
 

--- a/sample/shared/src/commonMain/kotlin/com/worldline/devview/sample/CounterScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/com/worldline/devview/sample/CounterScreen.kt
@@ -27,7 +27,7 @@ internal fun CounterScreen(modifier: Modifier = Modifier) {
     val viewModel = remember { CounterViewModel() }
     val state by viewModel.state.collectAsStateWithLifecycle()
 
-    TimeCapsuleEffect(owner = viewModel, label = { it.label })
+    TimeCapsuleEffect(owner = viewModel)
 
     Row(
         modifier = modifier,


### PR DESCRIPTION
## Summary
- TimeCapsule rows now show a per-state change summary (`count: 3 → 4`) diffed against the previous entry, expandable to reveal the full label with changed values highlighted — instead of a plain, two-line-truncated label with no way to read the rest.
- Rows carry a wall-clock timestamp alongside the existing delta, and the screen shows a "Recording {subtitle}" header naming the recorded owner (`TimeCapsuleEffect` gains a `subtitle` param, defaulting to the owner's class name).
- The row list is redesigned as a connected timeline: a node-and-line rail threads entries together, the most recent entry gets a soft halo, and the change summary uses muted/struck-through-old vs. bold/emphasized-new styling instead of plain text.
- Fixed padding-driven layout glitches (dead space on collapse), a ripple that ignored the row's rounded shape, and a rail that didn't track `AnimatedVisibility`'s animated height in sync.

**Breaking:** `TimeCapsuleEffect` gains a `subtitle` parameter between `label` and `maxEntries` — callers passing `maxEntries` positionally must switch to a named argument. Called out in `CHANGELOG.md`.

## Test plan
- [x] `:devview-timecapsule:testAndroidHostTest` — 22 unit tests pass (`FieldChange`/diff logic, `ScreenCapsule` subtitle resolution)
- [x] `detektFull` and `:konsist:test` pass
- [x] `:sample:androidApp:assembleDebug` builds and installs
- [x] Manually verified on device: change summaries, timestamp/delta pill, expand/collapse with highlighted diff, header, Restore (including re-recording), timeline rail halo/line, ripple clipping, and item-reflow animation on expand/collapse