### PR TITLE
fix: Persistent ViewModel

### DIFF
--- a/devview/build.gradle.kts
+++ b/devview/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
 
                 api(libs.kotlinx.collections.immutable)
                 api(projects.devviewUtils)
+                implementation(libs.jetbrains.androidx.lifecycle.viewmodel.navigation3)
             }
         }
     }

--- a/devview/src/commonMain/kotlin/com/worldline/devview/DevView.kt
+++ b/devview/src/commonMain/kotlin/com/worldline/devview/DevView.kt
@@ -28,9 +28,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import androidx.navigationevent.NavigationEventDispatcher
 import androidx.navigationevent.NavigationEventHandler
@@ -347,6 +349,10 @@ public fun DevView(
                             paddingValues = newPaddingValues
                         ),
                     backStack = backstack,
+                    entryDecorators = listOf(
+                        rememberSaveableStateHolderNavEntryDecorator(),
+                        rememberViewModelStoreNavEntryDecorator()
+                    ),
                     onBack = {
                         backstack.removeLastOrNull()
                     },


### PR DESCRIPTION
Causes navigation to always go through the first created ViewModel