### PR TITLE
feat: MockColorScheme for theme-aware NetworkMock status colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- NetworkMock status-family chip colors (2xx green, 4xx/5xx red, etc.) are now configurable via
+  a `LocalMockColorScheme` CompositionLocal, mirroring `devview-consolelogger`'s
+  `LocalLogColorScheme`. Also fixes these colors rendering as washed-out light pastels on dark
+  surfaces — `MockColorScheme.Dark` is a proper hand-tuned dark palette rather than the light
+  values reused verbatim. (`devview-networkmock`)
+
 ## [0.2.0-alpha02] - 2026-09-11
 
 ### Fixed

--- a/config/quality/detekt/compose-config.yml
+++ b/config/quality/detekt/compose-config.yml
@@ -12,7 +12,7 @@ Compose:
   CompositionLocalAllowlist:
     active: true
     # -- You can optionally define a list of CompositionLocals that are allowed here
-    allowedCompositionLocals: LocalLoading, LocalSharedTransitionScope, LocalAnimatedVisibilityScope, LocalWindowSizeClass, LocalFeatureHandler, LocalAnalytics, LocalConsoleLogs, LocalLogColorScheme
+    allowedCompositionLocals: LocalLoading, LocalSharedTransitionScope, LocalAnimatedVisibilityScope, LocalWindowSizeClass, LocalFeatureHandler, LocalAnalytics, LocalConsoleLogs, LocalLogColorScheme, LocalMockColorScheme
   CompositionLocalNaming:
     active: true
   ContentEmitterReturningValues:

--- a/devview-networkmock/CLAUDE.md
+++ b/devview-networkmock/CLAUDE.md
@@ -31,6 +31,8 @@ rememberModules {
 
 **Public UI models**: `ApiSpecUiModel` (one per spec tab) and `OperationUiModel` (pairs a static `OperationDescriptor` with a live `OperationMockState`).
 
+**Public theming**: `MockColorScheme` / `StatusColors` (`theme/MockColorScheme.kt`) and the `LocalMockColorScheme` CompositionLocal (`theme/LocalMockColorScheme.kt`) — see "Status colour theming" below.
+
 **Naming note**: internal Compose component names (`EndpointCard`, `EndpointStateChip`, `EndpointHeaderCard`, `MockItem`) and their test tags intentionally keep "endpoint" vocabulary — they're DevView's own UI implementation detail, not one of the types renamed to OpenAPI vocabulary by the 0.2.0 migration (`ApiSpecUiModel`, `OperationUiModel`, `OperationKey`, etc.).
 
 ## Internal Architecture
@@ -80,7 +82,11 @@ When the sheet is in `Compare` state, responses are diffed:
 
 ### Status code colors and icons
 
-`ModelUtils.kt` provides internal extension properties (`OperationMockState.icon`, `.contentColor`, `.containerColor`) that map HTTP status families (1xx–5xx) to hardcoded `Color` and `ImageVector` values. These are the only place to update if chip colours need changing.
+`ModelUtils.kt` provides internal extension properties (`OperationMockState.icon`, `.contentColor`, `.containerColor`) that map HTTP status families (1xx–5xx) to `ImageVector` values and — via `theme/MockColorScheme.kt` — theme-aware `Color` values. `iconForStatusCode`/`contentColorForStatusCode`/`containerColorForStatusCode` are the free-function equivalents used where there's no `OperationMockState` to hang the extension off of (e.g. `MockItem`'s per-response rows). The icon mapping is a plain `when` on numeric ranges; colours resolve through `theme/LocalMockColorScheme.kt`'s `rememberMockColorScheme()` — see "Status colour theming" below.
+
+### Status colour theming
+
+Mirrors `devview-consolelogger`'s `LogColorScheme` pattern exactly: `MockColorScheme` (`theme/MockColorScheme.kt`) holds two complete, hand-tuned palettes (`Light`/`Dark`) — one `StatusColors(container, content)` pair per `StatusCodeFamily` plus one for the `Network` pass-through state — deliberately not derived from `MaterialTheme.colorScheme`, since a 2xx chip needs to read as "success" regardless of the host's brand palette. Hosts provide a palette via the public `LocalMockColorScheme` CompositionLocal at their `MaterialTheme` site; `rememberMockColorScheme()` (internal, in `theme/LocalMockColorScheme.kt`) resolves it, falling back to a luminance-based guess against the ambient `MaterialTheme.colorScheme.surface` (not `isSystemInDarkTheme()` — DevView's theme may not track the system setting) with a one-time Kermit warning if the CompositionLocal was never provided. Because the colour extensions in `ModelUtils.kt` are themselves `@Composable @ReadOnlyComposable`, their test coverage for anything beyond the pure `MockColorScheme.get()`/`copy()` (`MockColorSchemeTest.kt`, `commonTest`) lives in `androidDeviceTest` (`ModelUtilsColorTest.kt`, `MockColorSchemeResolutionTest.kt`), not `commonTest`.
 
 ### Fake data for previews
 

--- a/devview-networkmock/api/api.txt
+++ b/devview-networkmock/api/api.txt
@@ -77,6 +77,59 @@ package com.worldline.devview.networkmock.model {
 
 }
 
+package com.worldline.devview.networkmock.theme {
+
+  public final class LocalMockColorSchemeKt {
+    method @InaccessibleFromKotlin public static androidx.compose.runtime.ProvidableCompositionLocal<com.worldline.devview.networkmock.theme.MockColorScheme?> getLocalMockColorScheme();
+    property public static androidx.compose.runtime.ProvidableCompositionLocal<com.worldline.devview.networkmock.theme.MockColorScheme?> LocalMockColorScheme;
+  }
+
+  @androidx.compose.runtime.Immutable public final class MockColorScheme {
+    ctor public MockColorScheme(com.worldline.devview.networkmock.theme.StatusColors informational, com.worldline.devview.networkmock.theme.StatusColors successful, com.worldline.devview.networkmock.theme.StatusColors redirection, com.worldline.devview.networkmock.theme.StatusColors clientError, com.worldline.devview.networkmock.theme.StatusColors serverError, com.worldline.devview.networkmock.theme.StatusColors unknown, com.worldline.devview.networkmock.theme.StatusColors network);
+    method public com.worldline.devview.networkmock.theme.StatusColors component1();
+    method public com.worldline.devview.networkmock.theme.StatusColors component2();
+    method public com.worldline.devview.networkmock.theme.StatusColors component3();
+    method public com.worldline.devview.networkmock.theme.StatusColors component4();
+    method public com.worldline.devview.networkmock.theme.StatusColors component5();
+    method public com.worldline.devview.networkmock.theme.StatusColors component6();
+    method public com.worldline.devview.networkmock.theme.StatusColors component7();
+    method public com.worldline.devview.networkmock.theme.MockColorScheme copy(optional com.worldline.devview.networkmock.theme.StatusColors informational, optional com.worldline.devview.networkmock.theme.StatusColors successful, optional com.worldline.devview.networkmock.theme.StatusColors redirection, optional com.worldline.devview.networkmock.theme.StatusColors clientError, optional com.worldline.devview.networkmock.theme.StatusColors serverError, optional com.worldline.devview.networkmock.theme.StatusColors unknown, optional com.worldline.devview.networkmock.theme.StatusColors network);
+    method public operator com.worldline.devview.networkmock.theme.StatusColors get(com.worldline.devview.networkmock.core.model.StatusCodeFamily family);
+    method @InaccessibleFromKotlin public com.worldline.devview.networkmock.theme.StatusColors getClientError();
+    method @InaccessibleFromKotlin public com.worldline.devview.networkmock.theme.StatusColors getInformational();
+    method @InaccessibleFromKotlin public com.worldline.devview.networkmock.theme.StatusColors getNetwork();
+    method @InaccessibleFromKotlin public com.worldline.devview.networkmock.theme.StatusColors getRedirection();
+    method @InaccessibleFromKotlin public com.worldline.devview.networkmock.theme.StatusColors getServerError();
+    method @InaccessibleFromKotlin public com.worldline.devview.networkmock.theme.StatusColors getSuccessful();
+    method @InaccessibleFromKotlin public com.worldline.devview.networkmock.theme.StatusColors getUnknown();
+    property public com.worldline.devview.networkmock.theme.StatusColors clientError;
+    property public com.worldline.devview.networkmock.theme.StatusColors informational;
+    property public com.worldline.devview.networkmock.theme.StatusColors network;
+    property public com.worldline.devview.networkmock.theme.StatusColors redirection;
+    property public com.worldline.devview.networkmock.theme.StatusColors serverError;
+    property public com.worldline.devview.networkmock.theme.StatusColors successful;
+    property public com.worldline.devview.networkmock.theme.StatusColors unknown;
+    field public static final com.worldline.devview.networkmock.theme.MockColorScheme.Companion Companion;
+  }
+
+  public static final class MockColorScheme.Companion {
+    method @InaccessibleFromKotlin public com.worldline.devview.networkmock.theme.MockColorScheme getDark();
+    method @InaccessibleFromKotlin public com.worldline.devview.networkmock.theme.MockColorScheme getLight();
+    property public com.worldline.devview.networkmock.theme.MockColorScheme Dark;
+    property public com.worldline.devview.networkmock.theme.MockColorScheme Light;
+  }
+
+  @androidx.compose.runtime.Immutable public final class StatusColors {
+    ctor @KotlinOnly public StatusColors(androidx.compose.ui.graphics.Color container, androidx.compose.ui.graphics.Color content);
+    method @KotlinOnly public operator androidx.compose.ui.graphics.Color component1();
+    method @KotlinOnly public operator androidx.compose.ui.graphics.Color component2();
+    method @KotlinOnly public com.worldline.devview.networkmock.theme.StatusColors copy(optional androidx.compose.ui.graphics.Color container, optional androidx.compose.ui.graphics.Color content);
+    property public androidx.compose.ui.graphics.Color container;
+    property public androidx.compose.ui.graphics.Color content;
+  }
+
+}
+
 package com.worldline.devview.networkmock.viewmodel {
 
   @androidx.compose.runtime.Immutable public sealed exhaustive interface NetworkMockEndpointUiState {

--- a/devview-networkmock/build.gradle.kts
+++ b/devview-networkmock/build.gradle.kts
@@ -23,6 +23,7 @@ kotlin {
                 api(projects.devviewNetworkmockCore)
                 implementation(libs.kotlinx.collections.immutable)
                 implementation(libs.jetbrains.androidx.lifecycle.viewmodel.compose)
+                implementation(libs.kermit)
             }
         }
 

--- a/devview-networkmock/src/androidDeviceTest/kotlin/com/worldline/devview/networkmock/theme/MockColorSchemeResolutionTest.kt
+++ b/devview-networkmock/src/androidDeviceTest/kotlin/com/worldline/devview/networkmock/theme/MockColorSchemeResolutionTest.kt
@@ -1,0 +1,42 @@
+package com.worldline.devview.networkmock.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.v2.runComposeUiTest
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+
+class MockColorSchemeResolutionTest {
+
+    @Test
+    fun rememberMockColorScheme_honours_explicit_LocalMockColorScheme() = runComposeUiTest {
+        var resolved: MockColorScheme? = null
+
+        setContent {
+            MaterialTheme(colorScheme = darkColorScheme()) {
+                CompositionLocalProvider(LocalMockColorScheme provides MockColorScheme.Light) {
+                    resolved = rememberMockColorScheme()
+                }
+            }
+        }
+        waitForIdle()
+
+        resolved shouldBe MockColorScheme.Light
+    }
+
+    @Test
+    fun rememberMockColorScheme_falls_back_to_dark_when_none_provided_and_theme_is_dark() =
+        runComposeUiTest {
+            var resolved: MockColorScheme? = null
+
+            setContent {
+                MaterialTheme(colorScheme = darkColorScheme()) {
+                    resolved = rememberMockColorScheme()
+                }
+            }
+            waitForIdle()
+
+            resolved shouldBe MockColorScheme.Dark
+        }
+}

--- a/devview-networkmock/src/androidDeviceTest/kotlin/com/worldline/devview/networkmock/utils/ModelUtilsColorTest.kt
+++ b/devview-networkmock/src/androidDeviceTest/kotlin/com/worldline/devview/networkmock/utils/ModelUtilsColorTest.kt
@@ -1,0 +1,113 @@
+package com.worldline.devview.networkmock.utils
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.v2.runComposeUiTest
+import com.worldline.devview.networkmock.core.model.OperationMockState
+import com.worldline.devview.networkmock.theme.LocalMockColorScheme
+import com.worldline.devview.networkmock.theme.MockColorScheme
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+
+// contentColorForStatusCode/containerColorForStatusCode and the OperationMockState color
+// extensions are @Composable (they read LocalMockColorScheme), so they need a composition —
+// see ModelUtilsTest in commonTest for the remaining pure (icon) coverage.
+class ModelUtilsColorTest {
+
+    @Test
+    fun contentColorForStatusCode_maps_HTTP_families_and_fallback() = runComposeUiTest {
+        val colors = mutableMapOf<Int?, Color>()
+
+        setContent {
+            MaterialTheme {
+                CompositionLocalProvider(LocalMockColorScheme provides MockColorScheme.Light) {
+                    colors[150] = contentColorForStatusCode(statusCode = 150)
+                    colors[250] = contentColorForStatusCode(statusCode = 250)
+                    colors[350] = contentColorForStatusCode(statusCode = 350)
+                    colors[450] = contentColorForStatusCode(statusCode = 450)
+                    colors[550] = contentColorForStatusCode(statusCode = 550)
+                    colors[null] = contentColorForStatusCode(statusCode = null)
+                    colors[700] = contentColorForStatusCode(statusCode = 700)
+                }
+            }
+        }
+        waitForIdle()
+
+        colors[150] shouldBe MockColorScheme.Light.informational.content
+        colors[250] shouldBe MockColorScheme.Light.successful.content
+        colors[350] shouldBe MockColorScheme.Light.redirection.content
+        colors[450] shouldBe MockColorScheme.Light.clientError.content
+        colors[550] shouldBe MockColorScheme.Light.serverError.content
+        colors[null] shouldBe MockColorScheme.Light.unknown.content
+        colors[700] shouldBe MockColorScheme.Light.unknown.content
+    }
+
+    @Test
+    fun containerColorForStatusCode_maps_HTTP_families_and_fallback() = runComposeUiTest {
+        val colors = mutableMapOf<Int?, Color>()
+
+        setContent {
+            MaterialTheme {
+                CompositionLocalProvider(LocalMockColorScheme provides MockColorScheme.Light) {
+                    colors[150] = containerColorForStatusCode(statusCode = 150)
+                    colors[250] = containerColorForStatusCode(statusCode = 250)
+                    colors[350] = containerColorForStatusCode(statusCode = 350)
+                    colors[450] = containerColorForStatusCode(statusCode = 450)
+                    colors[550] = containerColorForStatusCode(statusCode = 550)
+                    colors[null] = containerColorForStatusCode(statusCode = null)
+                    colors[700] = containerColorForStatusCode(statusCode = 700)
+                }
+            }
+        }
+        waitForIdle()
+
+        colors[150] shouldBe MockColorScheme.Light.informational.container
+        colors[250] shouldBe MockColorScheme.Light.successful.container
+        colors[350] shouldBe MockColorScheme.Light.redirection.container
+        colors[450] shouldBe MockColorScheme.Light.clientError.container
+        colors[550] shouldBe MockColorScheme.Light.serverError.container
+        colors[null] shouldBe MockColorScheme.Light.unknown.container
+        colors[700] shouldBe MockColorScheme.Light.unknown.container
+    }
+
+    @Test
+    fun operation_state_extensions_use_network_defaults() = runComposeUiTest {
+        var content: Color? = null
+        var container: Color? = null
+
+        setContent {
+            MaterialTheme {
+                CompositionLocalProvider(LocalMockColorScheme provides MockColorScheme.Light) {
+                    val state = OperationMockState.Network
+                    content = state.contentColor
+                    container = state.containerColor
+                }
+            }
+        }
+        waitForIdle()
+
+        content shouldBe MockColorScheme.Light.network.content
+        container shouldBe MockColorScheme.Light.network.container
+    }
+
+    @Test
+    fun operation_state_extensions_use_mock_status_code_mapping() = runComposeUiTest {
+        var content: Color? = null
+        var container: Color? = null
+
+        setContent {
+            MaterialTheme {
+                CompositionLocalProvider(LocalMockColorScheme provides MockColorScheme.Light) {
+                    val state = OperationMockState.Mock(statusCode = 404, exampleName = "default")
+                    content = state.contentColor
+                    container = state.containerColor
+                }
+            }
+        }
+        waitForIdle()
+
+        content shouldBe MockColorScheme.Light.clientError.content
+        container shouldBe MockColorScheme.Light.clientError.container
+    }
+}

--- a/devview-networkmock/src/commonMain/kotlin/com/worldline/devview/networkmock/theme/LocalMockColorScheme.kt
+++ b/devview-networkmock/src/commonMain/kotlin/com/worldline/devview/networkmock/theme/LocalMockColorScheme.kt
@@ -1,0 +1,69 @@
+package com.worldline.devview.networkmock.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.luminance
+import co.touchlab.kermit.Logger as KermitLogger
+
+/**
+ * CompositionLocal for providing the [MockColorScheme] used by the Network Mock module's UI.
+ *
+ * Provide this where your app already configures its `MaterialTheme`, so the status-family
+ * palette switches alongside your light/dark theme:
+ *
+ * ```kotlin
+ * MaterialTheme(colorScheme = if (darkTheme) darkColorScheme() else lightColorScheme()) {
+ *     CompositionLocalProvider(
+ *         LocalMockColorScheme provides if (darkTheme) MockColorScheme.Dark else MockColorScheme.Light
+ *     ) {
+ *         // ... DevView content ...
+ *     }
+ * }
+ * ```
+ *
+ * If never provided, the module falls back to [MockColorScheme.Light]/[MockColorScheme.Dark]
+ * chosen from the ambient `MaterialTheme`'s surface luminance, and logs a one-time warning
+ * pointing at this CompositionLocal (see the "Theming" guide).
+ *
+ * @see MockColorScheme
+ */
+public val LocalMockColorScheme: ProvidableCompositionLocal<MockColorScheme?> =
+    staticCompositionLocalOf { null }
+
+// ponytail: plain top-level flag, not thread-safe under concurrent first compositions.
+// Guards a diagnostic log line, not app state — a rare duplicate warning is harmless.
+private var hasWarnedMissingMockColorScheme = false
+
+/**
+ * Resolves the [MockColorScheme] to use: [LocalMockColorScheme] if provided, otherwise a
+ * best-effort guess derived from the ambient `MaterialTheme`'s surface luminance.
+ *
+ * The luminance-based guess intentionally does not use `isSystemInDarkTheme()` — DevView
+ * renders inside the host app's `MaterialTheme`, which may be driven by something other
+ * than the system setting (e.g. a feature flag), so the theme actually in effect is the
+ * only reliable signal.
+ */
+@Composable
+@ReadOnlyComposable
+internal fun rememberMockColorScheme(): MockColorScheme {
+    val provided = LocalMockColorScheme.current
+    if (provided != null) return provided
+
+    if (!hasWarnedMissingMockColorScheme) {
+        hasWarnedMissingMockColorScheme = true
+        KermitLogger.w(tag = "DevViewNetworkMock") {
+            "LocalMockColorScheme was never provided; falling back to a palette guessed " +
+                "from the current theme's surface luminance. Provide LocalMockColorScheme " +
+                "at your app's MaterialTheme site to fix this — see the Theming guide."
+        }
+    }
+
+    return if (MaterialTheme.colorScheme.surface.luminance() < 0.5f) {
+        MockColorScheme.Dark
+    } else {
+        MockColorScheme.Light
+    }
+}

--- a/devview-networkmock/src/commonMain/kotlin/com/worldline/devview/networkmock/theme/MockColorScheme.kt
+++ b/devview-networkmock/src/commonMain/kotlin/com/worldline/devview/networkmock/theme/MockColorScheme.kt
@@ -1,0 +1,153 @@
+package com.worldline.devview.networkmock.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import com.worldline.devview.networkmock.core.model.StatusCodeFamily
+
+/**
+ * The container/content color pair used to render a single [StatusCodeFamily] (or the
+ * [MockColorScheme.network] pass-through state) as a chip in the Network Mock UI.
+ *
+ * @property container Background color of the chip.
+ * @property content Foreground color (icon/label) of the chip.
+ *
+ * @see MockColorScheme
+ */
+@Immutable
+public data class StatusColors(public val container: Color, public val content: Color)
+
+/**
+ * The complete set of colors used to render HTTP status families and the network
+ * pass-through state in the Network Mock module's UI.
+ *
+ * DevView renders inside the host app's `MaterialTheme`, but these colors are intentionally
+ * not derived from `MaterialTheme.colorScheme` — a 2xx chip needs to read as "success" and a
+ * 4xx/5xx chip as "error" regardless of the host's brand palette. [Light] and [Dark] are
+ * complete, hand-tuned palettes tested for contrast in each theme; use [copy] to override
+ * individual families.
+ *
+ * ## Usage
+ *
+ * Provide the scheme where your app already configures its `MaterialTheme`, via
+ * [com.worldline.devview.networkmock.theme.LocalMockColorScheme]:
+ *
+ * ```kotlin
+ * MaterialTheme(colorScheme = if (darkTheme) darkColorScheme() else lightColorScheme()) {
+ *     CompositionLocalProvider(
+ *         LocalMockColorScheme provides if (darkTheme) MockColorScheme.Dark else MockColorScheme.Light
+ *     ) {
+ *         // ...
+ *     }
+ * }
+ * ```
+ *
+ * ### Overriding individual families
+ * ```kotlin
+ * MockColorScheme.Dark.copy(
+ *     serverError = MockColorScheme.Dark.serverError.copy(content = Color.Magenta)
+ * )
+ * ```
+ *
+ * @property informational Colors for [StatusCodeFamily.INFORMATIONAL] (1xx).
+ * @property successful Colors for [StatusCodeFamily.SUCCESSFUL] (2xx).
+ * @property redirection Colors for [StatusCodeFamily.REDIRECTION] (3xx).
+ * @property clientError Colors for [StatusCodeFamily.CLIENT_ERROR] (4xx).
+ * @property serverError Colors for [StatusCodeFamily.SERVER_ERROR] (5xx).
+ * @property unknown Colors for [StatusCodeFamily.UNKNOWN].
+ * @property network Colors for the network pass-through state (no mock active).
+ *
+ * @see StatusColors
+ * @see LocalMockColorScheme
+ */
+@Immutable
+public data class MockColorScheme(
+    public val informational: StatusColors,
+    public val successful: StatusColors,
+    public val redirection: StatusColors,
+    public val clientError: StatusColors,
+    public val serverError: StatusColors,
+    public val unknown: StatusColors,
+    public val network: StatusColors
+) {
+    /**
+     * Returns the [StatusColors] for the given [family].
+     */
+    public operator fun get(family: StatusCodeFamily): StatusColors = when (family) {
+        StatusCodeFamily.INFORMATIONAL -> informational
+        StatusCodeFamily.SUCCESSFUL -> successful
+        StatusCodeFamily.REDIRECTION -> redirection
+        StatusCodeFamily.CLIENT_ERROR -> clientError
+        StatusCodeFamily.SERVER_ERROR -> serverError
+        StatusCodeFamily.UNKNOWN -> unknown
+    }
+
+    public companion object {
+        /**
+         * The default light-theme palette.
+         */
+        public val Light: MockColorScheme = MockColorScheme(
+            informational = StatusColors(
+                container = Color(color = 0xFFB7DCEC),
+                content = Color(color = 0xFF184559)
+            ),
+            successful = StatusColors(
+                container = Color(color = 0xFFB7ECBA),
+                content = Color(color = 0xFF103C13)
+            ),
+            redirection = StatusColors(
+                container = Color(color = 0xFFF0CAA7),
+                content = Color(color = 0xFF603610)
+            ),
+            clientError = StatusColors(
+                container = Color(color = 0xFFECB7B7),
+                content = Color(color = 0xFF6F1111)
+            ),
+            serverError = StatusColors(
+                container = Color(color = 0xFFECB7E6),
+                content = Color(color = 0xFF611A59)
+            ),
+            unknown = StatusColors(
+                container = Color(color = 0xFFD1D1D1),
+                content = Color(color = 0xFF3D3D3D)
+            ),
+            network = StatusColors(
+                container = Color(color = 0xFFABC4ED),
+                content = Color(color = 0xFF0D1F3A)
+            )
+        )
+
+        /**
+         * The default dark-theme palette.
+         */
+        public val Dark: MockColorScheme = MockColorScheme(
+            informational = StatusColors(
+                container = Color(color = 0xFF70BAD9),
+                content = Color(color = 0xFF184559)
+            ),
+            successful = StatusColors(
+                container = Color(color = 0xFF70D976),
+                content = Color(color = 0xFF103C13)
+            ),
+            redirection = StatusColors(
+                container = Color(color = 0xFFE39C5B),
+                content = Color(color = 0xFF603610)
+            ),
+            clientError = StatusColors(
+                container = Color(color = 0xFFD97070),
+                content = Color(color = 0xFF500C0C)
+            ),
+            serverError = StatusColors(
+                container = Color(color = 0xFFD970CD),
+                content = Color(color = 0xFF45123F)
+            ),
+            unknown = StatusColors(
+                container = Color(color = 0xFFA4A4A4),
+                content = Color(color = 0xFF3D3D3D)
+            ),
+            network = StatusColors(
+                container = Color(color = 0xFF6290DD),
+                content = Color(color = 0xFF0D1F3A)
+            )
+        )
+    }
+}

--- a/devview-networkmock/src/commonMain/kotlin/com/worldline/devview/networkmock/utils/ModelUtils.kt
+++ b/devview-networkmock/src/commonMain/kotlin/com/worldline/devview/networkmock/utils/ModelUtils.kt
@@ -10,6 +10,8 @@ import androidx.compose.material.icons.rounded.CloudOff
 import androidx.compose.material.icons.rounded.ErrorOutline
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.Wifi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.capitalize
@@ -19,8 +21,10 @@ import com.worldline.devview.networkmock.core.model.Operation
 import com.worldline.devview.networkmock.core.model.OperationDescriptor
 import com.worldline.devview.networkmock.core.model.OperationKey
 import com.worldline.devview.networkmock.core.model.OperationMockState
+import com.worldline.devview.networkmock.core.model.StatusCodeFamily
 import com.worldline.devview.networkmock.model.ApiSpecUiModel
 import com.worldline.devview.networkmock.model.OperationUiModel
+import com.worldline.devview.networkmock.theme.rememberMockColorScheme
 import kotlinx.collections.immutable.toPersistentList
 
 internal fun ApiSpecUiModel.Companion.fake(amount: Int = 4): List<ApiSpecUiModel> =
@@ -84,34 +88,33 @@ internal fun iconForStatusCode(statusCode: Int?): ImageVector = when (statusCode
 }
 
 internal val OperationMockState.contentColor: Color
+    @Composable
+    @ReadOnlyComposable
     get() = when (this) {
         is OperationMockState.Mock -> contentColorForStatusCode(statusCode = statusCode)
-        OperationMockState.Network -> Color(color = 0xFF0D1F3A)
+        OperationMockState.Network -> rememberMockColorScheme().network.content
     }
 
-internal fun contentColorForStatusCode(statusCode: Int?): Color = when (statusCode) {
-    in 100..199 -> Color(color = 0xFF184559)
-    in 200..299 -> Color(color = 0xFF103C13)
-    in 300..399 -> Color(color = 0xFF603610)
-    in 400..499 -> Color(color = 0xFF6F1111)
-    in 500..599 -> Color(color = 0xFF611A59)
-    else -> Color(color = 0xFF3D3D3D)
-}
+@Composable
+@ReadOnlyComposable
+internal fun contentColorForStatusCode(statusCode: Int?): Color =
+    rememberMockColorScheme()[statusCode.toStatusCodeFamily()].content
 
 internal val OperationMockState.containerColor: Color
+    @Composable
+    @ReadOnlyComposable
     get() = when (this) {
         is OperationMockState.Mock -> containerColorForStatusCode(statusCode = statusCode)
-        OperationMockState.Network -> Color(color = 0xFFABC4ED)
+        OperationMockState.Network -> rememberMockColorScheme().network.container
     }
 
-internal fun containerColorForStatusCode(statusCode: Int?): Color = when (statusCode) {
-    in 100..199 -> Color(color = 0xFFB7DCEC)
-    in 200..299 -> Color(color = 0xFFB7ECBA)
-    in 300..399 -> Color(color = 0xFFF0CAA7)
-    in 400..499 -> Color(color = 0xFFECB7B7)
-    in 500..599 -> Color(color = 0xFFECB7E6)
-    else -> Color(color = 0xFFD1D1D1)
-}
+@Composable
+@ReadOnlyComposable
+internal fun containerColorForStatusCode(statusCode: Int?): Color =
+    rememberMockColorScheme()[statusCode.toStatusCodeFamily()].container
+
+private fun Int?.toStatusCodeFamily(): StatusCodeFamily =
+    this?.let { StatusCodeFamily.fromStatusCode(statusCode = it) } ?: StatusCodeFamily.UNKNOWN
 
 internal fun MockResponse.Companion.fake(amount: Int = 3): List<MockResponse> =
     List(size = amount) { index ->

--- a/devview-networkmock/src/commonTest/kotlin/com/worldline/devview/networkmock/theme/MockColorSchemeTest.kt
+++ b/devview-networkmock/src/commonTest/kotlin/com/worldline/devview/networkmock/theme/MockColorSchemeTest.kt
@@ -1,0 +1,37 @@
+package com.worldline.devview.networkmock.theme
+
+import androidx.compose.ui.graphics.Color
+import com.worldline.devview.networkmock.core.model.StatusCodeFamily
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class MockColorSchemeTest {
+
+    @Test
+    fun `get returns the matching slot for every family`() {
+        val scheme = MockColorScheme.Light
+
+        scheme[StatusCodeFamily.INFORMATIONAL] shouldBe scheme.informational
+        scheme[StatusCodeFamily.SUCCESSFUL] shouldBe scheme.successful
+        scheme[StatusCodeFamily.REDIRECTION] shouldBe scheme.redirection
+        scheme[StatusCodeFamily.CLIENT_ERROR] shouldBe scheme.clientError
+        scheme[StatusCodeFamily.SERVER_ERROR] shouldBe scheme.serverError
+        scheme[StatusCodeFamily.UNKNOWN] shouldBe scheme.unknown
+    }
+
+    @Test
+    fun `copy of one family leaves the others untouched`() {
+        val original = MockColorScheme.Dark
+        val overridden = original.copy(
+            serverError = original.serverError.copy(content = Color.Magenta)
+        )
+
+        overridden.serverError.content shouldBe Color.Magenta
+        overridden.informational shouldBe original.informational
+        overridden.successful shouldBe original.successful
+        overridden.redirection shouldBe original.redirection
+        overridden.clientError shouldBe original.clientError
+        overridden.unknown shouldBe original.unknown
+        overridden.network shouldBe original.network
+    }
+}

--- a/devview-networkmock/src/commonTest/kotlin/com/worldline/devview/networkmock/utils/ModelUtilsTest.kt
+++ b/devview-networkmock/src/commonTest/kotlin/com/worldline/devview/networkmock/utils/ModelUtilsTest.kt
@@ -7,8 +7,6 @@ import androidx.compose.material.icons.rounded.CheckCircleOutline
 import androidx.compose.material.icons.rounded.CloudOff
 import androidx.compose.material.icons.rounded.ErrorOutline
 import androidx.compose.material.icons.rounded.Info
-import androidx.compose.material.icons.rounded.Wifi
-import androidx.compose.ui.graphics.Color
 import com.worldline.devview.networkmock.core.model.MockResponse
 import com.worldline.devview.networkmock.core.model.OperationDescriptor
 import com.worldline.devview.networkmock.core.model.OperationMockState
@@ -18,6 +16,9 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 
+// contentColorForStatusCode/containerColorForStatusCode and OperationMockState.contentColor/
+// containerColor are @Composable (they read LocalMockColorScheme) — covered in the
+// androidDeviceTest ModelUtilsColorTest instead, which can provide a composition.
 class ModelUtilsTest {
 
     @Test
@@ -30,48 +31,6 @@ class ModelUtilsTest {
 
         iconForStatusCode(statusCode = null) shouldBe Icons.AutoMirrored.Rounded.HelpOutline
         iconForStatusCode(statusCode = 42) shouldBe Icons.AutoMirrored.Rounded.HelpOutline
-    }
-
-    @Test
-    fun `contentColorForStatusCode maps HTTP families and fallback`() {
-        contentColorForStatusCode(statusCode = 150) shouldBe Color(color = 0xFF184559)
-        contentColorForStatusCode(statusCode = 250) shouldBe Color(color = 0xFF103C13)
-        contentColorForStatusCode(statusCode = 350) shouldBe Color(color = 0xFF603610)
-        contentColorForStatusCode(statusCode = 450) shouldBe Color(color = 0xFF6F1111)
-        contentColorForStatusCode(statusCode = 550) shouldBe Color(color = 0xFF611A59)
-
-        contentColorForStatusCode(statusCode = null) shouldBe Color(color = 0xFF3D3D3D)
-        contentColorForStatusCode(statusCode = 700) shouldBe Color(color = 0xFF3D3D3D)
-    }
-
-    @Test
-    fun `containerColorForStatusCode maps HTTP families and fallback`() {
-        containerColorForStatusCode(statusCode = 150) shouldBe Color(color = 0xFFB7DCEC)
-        containerColorForStatusCode(statusCode = 250) shouldBe Color(color = 0xFFB7ECBA)
-        containerColorForStatusCode(statusCode = 350) shouldBe Color(color = 0xFFF0CAA7)
-        containerColorForStatusCode(statusCode = 450) shouldBe Color(color = 0xFFECB7B7)
-        containerColorForStatusCode(statusCode = 550) shouldBe Color(color = 0xFFECB7E6)
-
-        containerColorForStatusCode(statusCode = null) shouldBe Color(color = 0xFFD1D1D1)
-        containerColorForStatusCode(statusCode = 700) shouldBe Color(color = 0xFFD1D1D1)
-    }
-
-    @Test
-    fun `operation state extension properties use network defaults`() {
-        val state = OperationMockState.Network
-
-        state.icon shouldBe Icons.Rounded.Wifi
-        state.contentColor shouldBe Color(color = 0xFF0D1F3A)
-        state.containerColor shouldBe Color(color = 0xFFABC4ED)
-    }
-
-    @Test
-    fun `operation state extension properties use mock status code mapping`() {
-        val state = OperationMockState.Mock(statusCode = 404, exampleName = "default")
-
-        state.icon shouldBe Icons.Rounded.ErrorOutline
-        state.contentColor shouldBe Color(color = 0xFF6F1111)
-        state.containerColor shouldBe Color(color = 0xFFECB7B7)
     }
 
     @Test

--- a/docs/guides/theming.md
+++ b/docs/guides/theming.md
@@ -74,6 +74,41 @@ to wire up `LocalLogColorScheme` explicitly. The fallback deliberately does not 
 system setting (e.g. a feature flag), and the theme actually in effect is the only reliable
 signal.
 
+## Network Mock Status Colors
+
+Like the Console Logger's `LogColorScheme`, the Network Mock module's per-status-family colors
+(2xx green, 4xx/5xx red, etc.) are **not** derived from `MaterialTheme.colorScheme` — a mocked
+2xx response needs to read as "success" regardless of your app's brand colors. `MockColorScheme.Light`
+and `MockColorScheme.Dark` are two complete, hand-tuned palettes chosen for contrast in each theme.
+
+Provide the palette where you already configure your app's `MaterialTheme`, so it switches
+alongside your light/dark theme:
+
+```kotlin
+MaterialTheme(colorScheme = if (darkTheme) darkColorScheme() else lightColorScheme()) {
+    CompositionLocalProvider(
+        LocalMockColorScheme provides if (darkTheme) MockColorScheme.Dark else MockColorScheme.Light
+    ) {
+        // ... DevView content ...
+    }
+}
+```
+
+Override individual status families with `copy()`:
+
+```kotlin
+MockColorScheme.Dark.copy(
+    serverError = MockColorScheme.Dark.serverError.copy(content = Color.Magenta)
+)
+```
+
+**If `LocalMockColorScheme` is never provided**, the module logs a one-time warning (tag
+`DevViewNetworkMock`) and falls back to `MockColorScheme.Light`/`MockColorScheme.Dark` guessed
+from the ambient `MaterialTheme`'s surface luminance — usually correct, but the warning is your
+cue to wire up `LocalMockColorScheme` explicitly. As with the console, the fallback deliberately
+does not use `isSystemInDarkTheme()`, since DevView's theme may be driven by something other
+than the system setting.
+
 ## Customising Typography
 Use your app's typography settings in custom modules:
 ```kotlin

--- a/docs/modules/networkmock-ui.md
+++ b/docs/modules/networkmock-ui.md
@@ -22,6 +22,13 @@ Shows the full endpoint info and all discovered mock response files, grouped by 
 - **Response items**: tap to activate a mock response (shown with its status code chip); long-press to open a preview bottom sheet.
 - **Preview bottom sheet**: shows the response file contents. Long-press a second response to enter compare mode, which renders a side-by-side or inline diff (LCS-based, collapses long unchanged runs).
 
+## Theming
+
+Status-family colors (2xx green, 4xx/5xx red, etc.) are a fixed, hand-tuned palette per
+theme, not derived from `MaterialTheme.colorScheme` — see the
+[Theming guide](../guides/theming.md#network-mock-status-colors) for how to provide and
+override them.
+
 ## Registration
 
 ```kotlin


### PR DESCRIPTION
## Summary
- NetworkMock's status-family chip colors (2xx green, 4xx/5xx red, etc.) were 18 hardcoded light-theme hex values in `ModelUtils.kt` — pale pastel-on-dark-text chips on a dark surface.
- Adds `MockColorScheme`/`StatusColors` + `LocalMockColorScheme`, mirroring `devview-consolelogger`'s `LogColorScheme`/`LocalLogColorScheme` pattern exactly: hand-tuned `Light`/`Dark` palettes, a public CompositionLocal for host overrides, and a luminance-based fallback with a one-time Kermit warning if never provided.
- `Light` is the existing values verbatim (no visual change for light theme); `Dark` is a derived palette validated for ≥4.5:1 contrast on every status family.
- Part 1 of a 3-PR NetworkMock UI overhaul (see plan); purely additive, no breaking changes.

## Test plan
- [x] `:devview-networkmock:testAndroidHostTest` — commonTest + androidHostTest green
- [x] `:devview-networkmock:metalavaGenerateSignature` — additive-only api.txt diff
- [x] `detektFull` — green (added `LocalMockColorScheme` to the `CompositionLocalAllowlist`)
- [x] `:konsist:test` — green
- [ ] `connectedAndroidDeviceTest` — new `MockColorSchemeResolutionTest` / `ModelUtilsColorTest` need an emulator/device to run
- [ ] Manual: sample app in light + dark, confirm status chips are legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)